### PR TITLE
recordingmerger: Fix producing union of SELinux permissions

### DIFF
--- a/internal/pkg/manager/recordingmerger/merge_utils.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils.go
@@ -185,8 +185,19 @@ func addAllow(union, additional selinuxprofileapi.Allow) selinuxprofileapi.Allow
 		if _, ok := union[labelKey]; !ok {
 			union[labelKey] = make(map[selinuxprofileapi.ObjectClassKey]selinuxprofileapi.PermissionSet)
 		}
+
 		for objClass, perms := range permMap {
-			union[labelKey][objClass] = append(union[labelKey][objClass], perms...)
+			allPerms := map[string]bool{}
+			for _, havePerm := range union[labelKey][objClass] {
+				allPerms[havePerm] = true
+			}
+
+			for _, newPerm := range perms {
+				_, ok := allPerms[newPerm]
+				if !ok {
+					union[labelKey][objClass] = append(union[labelKey][objClass], newPerm)
+				}
+			}
 		}
 	}
 

--- a/internal/pkg/manager/recordingmerger/merge_utils_test.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils_test.go
@@ -153,7 +153,7 @@ func TestMergeProfiles(t *testing.T) {
 								},
 							},
 							Allow: selinuxprofileapi.Allow{
-								"label_foo": {"oc_bar2": {"do_bar2"}, "oc_baz2": {"do_baz2"}},
+								"label_foo": {"oc_bar": {"do_bar"}, "oc_bar2": {"do_bar2"}, "oc_baz2": {"do_baz2"}},
 								"label_aaa": {"oc_aaa": {"do_aaa"}, "oc_bbb": {"do_bbb"}},
 							},
 						},


### PR DESCRIPTION
We were naively appending all permissions from the SELinux profile about to be merged, this was causing potential duplicates. Let's check if the permission is already present before merging it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Syncs a bugfix for https://issues.redhat.com/browse/CMP-1673 to downstream

#### Which issue(s) this PR fixes:
[CMP-1673](https://issues.redhat.com/browse/CMP-1673)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
