### PR TITLE
OLM: Add an OpenShift-specific annotation

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -101,6 +101,8 @@ metadata:
     olm.skipRange: '>=0.4.1 <0.5.0'
     operatorframework.io/suggested-namespace: security-profiles-operator
     operators.operatorframework.io/builder: operator-sdk-v1.22.2
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
+      Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: security-profiles-operator.v0.5.0
   namespace: placeholder

--- a/deploy/base/clusterserviceversion.yaml
+++ b/deploy/base/clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
     categories: Security
     olm.skipRange: '>=0.4.1 <0.4.2-dev'
     operatorframework.io/suggested-namespace: security-profiles-operator
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
   name: security-profiles-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
It was detected by our CVP tests that the SPO CSV is missing a required annotation

Link to the failed CVP test (requires RH VPN):
http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/security-profiles-operator-bundle-container-0.5.0-22/5e0bd44f-642d-4f31-9090-9cbac4f82bca/operator-valid-subscriptions-bundle-image-output.txt

Link to the gdoc that tracks optional operators and their subscriptions (requires RH account):
https://docs.google.com/document/d/14gj6dv-jZlTPJVOfzSCy7V2JKJCKcRgpGCkWoydL9Ig/edit#