### PR TITLE
OCPBUGS-3963: Fix SPO installation methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ GOLANGCI_LINT_VERSION = v1.49.0
 REPO_INFRA_VERSION = v0.2.5
 KUSTOMIZE_VERSION = 4.5.5
 OPERATOR_SDK_VERSION ?= v1.22.2
-OPM_VERSION ?= v1.19.1
 
 CONTROLLER_GEN_CMD := CGO_LDFLAGS= $(GO) run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen
 
@@ -514,7 +513,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPERATOR_SDK_VERSION)/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/Makefile
+++ b/Makefile
@@ -482,10 +482,12 @@ OLM_EXAMPLES := \
 	examples/seccompprofile.yaml \
 	examples/selinuxprofile.yaml
 
+BUNDLE_SA_OPTS ?= --extra-service-accounts security-profiles-operator,spod,spo-webhook
+
 .PHONY: bundle
 bundle: operator-sdk deployments ## Generate bundle manifests and metadata, then validate generated files.
 	sed -i "s/\(olm.skipRange: '>=.*\)<.*'/\1<$(VERSION)'/" deploy/base/clusterserviceversion.yaml
-	cat $(OLM_EXAMPLES) $(BUNDLE_OPERATOR_MANIFEST) deploy/base/clusterserviceversion.yaml | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	cat $(OLM_EXAMPLES) $(BUNDLE_OPERATOR_MANIFEST) deploy/base/clusterserviceversion.yaml | $(OPERATOR_SDK) generate bundle -q --overwrite $(BUNDLE_SA_OPTS) --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	git restore deploy/base/clusterserviceversion.yaml
 	mkdir -p ./bundle/tests/scorecard
 	cp deploy/bundle-test-config.yaml ./bundle/tests/scorecard/config.yaml

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -407,6 +407,277 @@ spec:
           - patch
           - update
         serviceAccountName: security-profiles-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - profilebindings
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - profilebindings/finalizers
+          verbs:
+          - delete
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - profilebindings/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - profilerecordings
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - profilerecordings/finalizers
+          verbs:
+          - delete
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - profilerecordings/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - seccompprofiles
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - selinuxprofiles
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: spo-webhook
+      - rules:
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - subjectaccessreviews
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - apparmorprofiles
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - apparmorprofiles/finalizers
+          verbs:
+          - delete
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - apparmorprofiles/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - profilerecordings
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - rawselinuxprofiles
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - rawselinuxprofiles/finalizers
+          verbs:
+          - delete
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - rawselinuxprofiles/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - seccompprofiles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - seccompprofiles/finalizers
+          verbs:
+          - delete
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - seccompprofiles/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - securityprofilenodestatuses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - securityprofilesoperatordaemons
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - selinuxprofiles
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - selinuxprofiles/finalizers
+          verbs:
+          - delete
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security-profiles-operator.x-k8s.io
+          resources:
+          - selinuxprofiles/status
+          verbs:
+          - get
+          - patch
+          - update
+        serviceAccountName: spod
       deployments:
       - label:
           app: security-profiles-operator
@@ -483,6 +754,38 @@ spec:
           verbs:
           - use
         serviceAccountName: security-profiles-operator
+      - rules:
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - create
+        - apiGroups:
+          - coordination.k8s.io
+          resourceNames:
+          - security-profiles-operator-webhook-lock
+          resources:
+          - leases
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: spo-webhook
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: spod
     strategy: deployment
   installModes:
   - supported: true

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -489,9 +489,9 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: false
+  - supported: true
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - security

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -436,6 +436,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 image: k8s.gcr.io/security-profiles-operator/security-profiles-operator:v0.5.0
                 imagePullPolicy: Always
                 name: security-profiles-operator

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -349,10 +349,14 @@ func runManager(ctx *cli.Context, info *version.Info) error {
 }
 
 func setControllerOptionsForNamespaces(opts *ctrl.Options) {
-	namespace := os.Getenv(config.RestrictNamespaceEnvKey)
+	namespace, ok := os.LookupEnv(config.RestrictNamespaceEnvKey)
+	if !ok {
+		namespace = os.Getenv("WATCH_NAMESPACE")
+	}
 
 	// listen globally
 	if namespace == "" {
+		setupLog.Info("watching all namespaces")
 		opts.Namespace = namespace
 		return
 	}
@@ -370,9 +374,11 @@ func setControllerOptionsForNamespaces(opts *ctrl.Options) {
 	// Adding "" adds cluster namespaced resources
 	if strings.Contains(namespace, ",") {
 		opts.NewCache = cache.MultiNamespacedCacheBuilder(namespaceList)
+		setupLog.Info("watching multiple namespaces", "namespaces", namespaceList)
 	} else {
 		// listen to a specific namespace only
 		opts.Namespace = namespace
+		setupLog.Info("watching single namespace", "namespace", namespace)
 	}
 }
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -39,14 +39,6 @@ dependencies:
     - path: Makefile
       match: OPERATOR_SDK_VERSION
 
-  - name: opm
-    version: 1.19.1
-    refPaths:
-    - path: Makefile
-      match: OPM_VERSION
-    - path: hack/image-cross.sh
-      match: OPM_VERSION
-
   - name: olm
     version: v0.18.2
     refPaths:

--- a/deploy/base/clusterserviceversion.yaml
+++ b/deploy/base/clusterserviceversion.yaml
@@ -67,9 +67,9 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: false
+  - supported: true
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - security

--- a/deploy/kustomize-deployment/manager_deployment.yaml
+++ b/deploy/kustomize-deployment/manager_deployment.yaml
@@ -42,6 +42,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.annotations['olm.targetNamespaces']
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2936,6 +2936,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.annotations['olm.targetNamespaces']
         image: k8s.gcr.io/security-profiles-operator/security-profiles-operator:v0.5.0
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2934,6 +2934,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.annotations['olm.targetNamespaces']
         image: k8s.gcr.io/security-profiles-operator/security-profiles-operator:v0.5.0
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2934,6 +2934,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.annotations['olm.targetNamespaces']
         image: k8s.gcr.io/security-profiles-operator/security-profiles-operator:v0.5.0
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2934,6 +2934,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.annotations['olm.targetNamespaces']
         image: k8s.gcr.io/security-profiles-operator/security-profiles-operator:v0.5.0
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/examples/olm/install-resources.yaml
+++ b/examples/olm/install-resources.yaml
@@ -21,9 +21,6 @@ kind: OperatorGroup
 metadata:
   name: security-profiles-operator
   namespace: security-profiles-operator
-spec:
-  targetNamespaces:
-  - security-profiles-operator
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription

--- a/examples/olm/install-resources.yaml
+++ b/examples/olm/install-resources.yaml
@@ -16,12 +16,6 @@ spec:
   sourceType: grpc
   image: k8s.gcr.io/security-profiles-operator/security-profiles-operator-catalog:v0.5.0
 ---
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: security-profiles-operator
-  namespace: security-profiles-operator
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -33,3 +27,9 @@ spec:
   source: security-profiles-operator
   #sourceNamespace: openshift-marketplace on OCP
   sourceNamespace: olm
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: security-profiles-operator
+  namespace: security-profiles-operator

--- a/hack/ci/e2e-olm.sh
+++ b/hack/ci/e2e-olm.sh
@@ -22,6 +22,19 @@ IMG=${REPO}/security-profiles-operator:${GITHUB_SHA}
 BUNDLE_IMG=${REPO}/security-profiles-operator-bundle:v${GITHUB_SHA}
 CATALOG_IMG=${REPO}/security-profiles-operator-catalog:v${GITHUB_SHA}
 
+function sp_in_ns() {
+    ns=$1
+kubectl create -f - << EOF
+apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+kind: SeccompProfile
+metadata:
+  name: log-all
+  namespace: $ns
+spec:
+  defaultAction: "SCMP_ACT_LOG"
+EOF
+}
+
 function build_and_push_spo() {
     make image IMAGE=${IMG}
     podman push --tls-verify=false ${IMG}
@@ -49,30 +62,112 @@ function build_and_push_packages() {
     podman push --tls-verify=false ${CATALOG_IMG}
 }
 
-function deploy_olm() {
+function deploy_deps() {
+    # we need OLM
     operator-sdk olm install --version ${OLM_VERSION} --timeout 6m
-}
 
-function deploy_spo() {
     # cert-manager first. This should be done using dependencies in the
     # future
     kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
     kubectl -ncert-manager wait --for condition=ready pod -l app.kubernetes.io/instance=cert-manager
 
-    # let's roll..
+    # All installation methods run off the same catalog
     sed -i "s#k8s.gcr.io/security-profiles-operator/security-profiles-operator-catalog:v0.5.0#${CATALOG_IMG}#g" examples/olm/install-resources.yaml
-    kubectl create -f examples/olm/install-resources.yaml
+
+}
+
+function deploy_spo_in_custom_ns() {
+    ns=$1
+    manifests=examples/olm/custom-install-resources.yaml
+
+cat << EOF > $manifests
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $ns
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: security-profiles-operator
+  # namespace: openshift-marketplace on OCP
+  namespace: olm
+spec:
+  sourceType: grpc
+  image: $CATALOG_IMG
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: security-profiles-operator-sub
+  namespace: $ns
+spec:
+  channel: stable
+  name: security-profiles-operator
+  source: security-profiles-operator
+  sourceNamespace: olm
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: security-profiles-operator
+  namespace: $ns
+EOF
+
+echo "Installing manifest for custom ns installation.."
+cat $manifests
+
+kubectl create -f $manifests
+}
+
+function deploy_spo() {
+    installation_method=$1
+    manifests=examples/olm/$installation_method-install-resources.yaml
+
+    cp examples/olm/install-resources.yaml $manifests
+
+    case $installation_method in
+    all)
+        ;;
+    own)
+        echo "spec:
+  targetNamespaces:
+  - security-profiles-operator" >> $manifests
+        ;;
+    single)
+        echo "spec:
+  targetNamespaces:
+  - spo-sp-ns" >> $manifests
+        ;;
+    multi)
+        echo "spec:
+  targetNamespaces:
+  - sp-test-1
+  - sp-test-2" >> $manifests
+        ;;
+    esac
+
+    # let's roll..
+    kubectl create -f $manifests
 }
 
 function check_spo_is_running() {
+    ns=$1
+
     # Useful in case the CatalogSource is fubar. We retry several times
     # because on transient errors (which are for some reason common even
     # if the catalog is local) the pod gets restarted
     for i in $(seq 1 5); do
         kubectl -nolm wait --for=condition=ready pods -lolm.catalogSource=security-profiles-operator
-        catalog_logs=$(kubectl -nolm logs $(kubectl -nolm get pods --no-headers -lolm.catalogSource=security-profiles-operator | awk '{print $1}') 2>/dev/null)
-        if [[ -n "$catalog_logs" ]]; then
+        install_rv=$?
+        if [ $install_rv -ne 0 ]; then
+            catalog_logs=$(kubectl -nolm logs $(kubectl -nolm get pods --no-headers -lolm.catalogSource=security-profiles-operator | awk '{print $1}') 2>/dev/null)
             echo $catalog_logs
+            kubectl -nolm describe pods -lolm.catalogSource=security-profiles-operator
+        else
             break
         fi
     done
@@ -81,30 +176,212 @@ function check_spo_is_running() {
     # (jhrozek): I didn't find a useful condition or status to wait for..
     # ..if only there was a way to check if ANY installedCSV is set..
     sleep 30
-    CSV=$(kubectl -nsecurity-profiles-operator get sub security-profiles-operator-sub -ojsonpath='{.status.installedCSV}')
+    CSV=$(kubectl -n$ns get sub security-profiles-operator-sub -ojsonpath='{.status.installedCSV}')
     # wait for the CSV to be actually installed
-    kubectl -nsecurity-profiles-operator wait --for=jsonpath='{.status.phase}'=Succeeded csv $CSV
+    kubectl -n$ns wait --for=jsonpath='{.status.phase}'=Succeeded csv $CSV
 
     # wait for the operator to be ready
-    kubectl -nsecurity-profiles-operator wait --for=condition=ready pod -lname=security-profiles-operator
-    kubectl -nsecurity-profiles-operator wait --for=condition=ready pod -lname=security-profiles-operator-webhook
+    kubectl -n$ns wait --for=condition=ready pod -lname=security-profiles-operator || return 1
 
-    # wait for spod pod to be created, kubectl wait for un-existed resource seems to exit with error
+    # wait for webhook deploy to be created, kubectl wait for non-existent resource seems to exit with error
     # which is causing random test failure
     # see https://github.com/kubernetes/kubernetes/issues/83242
     for i in $(seq 1 10); do
-        found=$(kubectl get -nsecurity-profiles-operator pods -lname=spod 2>/dev/null)
+        found=$(kubectl -n$ns wait --for=condition=ready pod -lname=security-profiles-operator-webhook 2>/dev/null)
         if [[ $found ]]; then
             break
         fi
         sleep 5
     done
-    kubectl -nsecurity-profiles-operator wait --for=condition=ready pod -lname=spod
+    kubectl -n$ns wait --for=condition=ready pod -lname=security-profiles-operator-webhook || return 1
+
+    # wait for spod pod to be created, kubectl wait for non-existent resource seems to exit with error
+    # which is causing random test failure
+    # see https://github.com/kubernetes/kubernetes/issues/83242
+    for i in $(seq 1 10); do
+        found=$(kubectl get -n$ns pods -lname=spod 2>/dev/null)
+        if [[ $found ]]; then
+            break
+        fi
+        sleep 5
+    done
+    kubectl -n$ns wait --for=condition=ready pod -lname=spod || return 1
+
+    return 0
+}
+
+function assert_spo_csv_installed_in_ns() {
+    ns=$1
+
+    [[ $(kubectl get csv -loperators.coreos.com/security-profiles-operator.$ns= -n$ns -oname) ]] || return 1
+}
+
+function assert_spo_csv_copied_to() {
+    ns=$1
+    from=$2
+
+    [[ $(kubectl get csv -lolm.copiedFrom=$from -n$ns -oname) ]] || return 1
+}
+
+
+function smoke_test_all() {
+    kubectl create ns sp-test-1
+    sp_in_ns sp-test-1
+    kubectl wait --for=condition=ready -nsp-test-1 sp log-all || return 1
+
+    kubectl create ns sp-test-2
+    sp_in_ns sp-test-2
+    kubectl wait --for=condition=ready -nsp-test-2 sp log-all || return 1
+
+    kubectl delete sp --all --all-namespaces
+    kubectl delete ns sp-test-{1,2}
+
+    # in this installation method, the CSV is installed into security-profiles-operator
+    # and copied into all others
+    assert_spo_csv_installed_in_ns security-profiles-operator || return 1
+    assert_spo_csv_copied_to default security-profiles-operator || return 1
+
+    return 0
+}
+
+function smoke_test_own() {
+    sp_in_ns security-profiles-operator
+    kubectl wait --for=condition=ready -nsecurity-profiles-operator sp log-all || return 1
+
+    kubectl create ns sp-test-neg
+    sp_in_ns sp-test-neg
+    kubectl wait --for=condition=ready -nsp-test-neg sp log-all && return 1
+
+    kubectl delete sp --all --all-namespaces
+    kubectl delete ns sp-test-neg
+
+    # in this installation method, the CSV is installed into
+    # security-profiles-operator ns only
+    assert_spo_csv_installed_in_ns security-profiles-operator || return 1
+    assert_spo_csv_copied_to default security-profiles-operator && return 1
+
+    return 0
+}
+
+function smoke_test_single() {
+    kubectl create ns spo-sp-ns
+    sp_in_ns spo-sp-ns
+    kubectl wait --for=condition=ready -nspo-sp-ns sp log-all || return 1
+
+    kubectl create ns sp-test-neg
+    sp_in_ns sp-test-neg
+    kubectl wait --for=condition=ready -nsp-test-neg sp log-all && return 1
+
+    # SPO always adds its own ns regardless even if not watched explicitly
+    sp_in_ns security-profiles-operator
+    kubectl wait --for=condition=ready -nsecurity-profiles-operator sp log-all || return 1
+
+    kubectl delete sp --all --all-namespaces
+    kubectl delete ns spo-sp-ns sp-test-neg
+
+    # in this installation method, the CSV is installed into
+    # security-profiles-operator ns only
+    assert_spo_csv_installed_in_ns security-profiles-operator || return 1
+    assert_spo_csv_copied_to default security-profiles-operator && return 1
+
+    return 0
+}
+
+function smoke_test_multi() {
+    kubectl create ns sp-test-1
+    sp_in_ns sp-test-1
+    kubectl wait --for=condition=ready -nsp-test-1 sp log-all || return 1
+
+    kubectl create ns sp-test-2
+    sp_in_ns sp-test-2
+    kubectl wait --for=condition=ready -nsp-test-2 sp log-all || return 1
+
+    # SPO always adds its own ns regardless even if not watched explicitly
+    sp_in_ns security-profiles-operator
+    kubectl wait --for=condition=ready -nsecurity-profiles-operator sp log-all || return 1
+
+    # negative test, we listen for sp-test-{1,2} only
+    kubectl create ns sp-test-3
+    sp_in_ns sp-test-3
+    kubectl wait --for=condition=ready -nsp-test-3 sp log-all && return 1
+
+    kubectl delete sp --all --all-namespaces
+    kubectl delete ns sp-test-{1,2,3}
+
+    # in this installation method, the CSV is installed into
+    # security-profiles-operator ns only
+    assert_spo_csv_installed_in_ns security-profiles-operator || return 1
+    assert_spo_csv_copied_to default security-profiles-operator && return 1
+
+    return 0
+}
+
+function smoke_test_custom() {
+    kubectl create ns sp-test-1
+    sp_in_ns sp-test-1
+    kubectl wait --for=condition=ready -nsp-test-1 sp log-all || return 1
+
+    kubectl create ns sp-test-2
+    sp_in_ns sp-test-2
+    kubectl wait --for=condition=ready -nsp-test-2 sp log-all || return 1
+
+    sp_in_ns spo-lives-here
+    kubectl wait --for=condition=ready -nspo-lives-here sp log-all || return 1
+
+    kubectl delete sp --all --all-namespaces
+    kubectl delete ns sp-test-1 sp-test-2
+
+    # SPO CSV is installed into the spo-lives-here ns and copied everywhere
+    assert_spo_csv_installed_in_ns spo-lives-here || return 1
+    assert_spo_csv_copied_to default spo-lives-here || return 1
+
+    return 0
+}
+
+function smoke_test() {
+    installation_method=$1
+
+    rv=1 # be pessimistic
+    smoke_test_$installation_method
+    rv=$?
+    echo "Smoke test for $installation_method returned $rv"
+
+    return $rv
+}
+
+function teardown_spo() {
+    installation_method=$1
+    manifests=examples/olm/$installation_method-install-resources.yaml
+
+    # profiles might have finalizers
+    kubectl delete sp --all --all-namespaces
+
+    kubectl delete -f $manifests
 }
 
 # The actual script begins here
 build_and_push_spo
 build_and_push_packages
-deploy_olm
-deploy_spo
-check_spo_is_running
+
+deploy_deps
+
+rv=0
+for method in all own single multi; do
+    echo "Testing SPO deployment in $method namespace(s)"
+
+    deploy_spo $method || rv=1
+    check_spo_is_running security-profiles-operator || rv=1
+    smoke_test $method || rv=1
+
+    teardown_spo $method
+done
+
+# deployment into the custom namespace is a bit special
+echo "Testing SPO deployment in custom namespace(s)"
+deploy_spo_in_custom_ns spo-lives-here || rv=1
+check_spo_is_running spo-lives-here || rv=1
+kubectl get csv -A --show-labels
+smoke_test_custom || rv=1
+teardown_spo custom
+
+exit $rv

--- a/hack/image-cross.sh
+++ b/hack/image-cross.sh
@@ -63,21 +63,6 @@ for T in "${TAGS[@]}"; do
     docker manifest push --purge "$IMAGE:$T"
 done
 
-# Manually install OPM because of failing symbol relocation of the non-static
-# upstream binary build.
-# TODO: remove me when switching to a new OPM version, which are nowadays
-# correctly statically linked.
-OPM_VERSION=1.19.1
-OPM_REPO=operator-registry
-OPM_DIR=$OPM_REPO-$OPM_VERSION
-apk add --no-cache gcc libc-dev
-curl -sSfL --retry 5 --retry-delay 3 \
-    "https://github.com/operator-framework/$OPM_REPO/archive/refs/tags/v$OPM_VERSION.tar.gz" -o- |
-    tar xfz -
-make -C $OPM_DIR bin/opm CGO_LDFLAGS=
-mkdir -p build
-cp $OPM_DIR/bin/opm build/opm
-
 # Build and push the bundle and catalog image
 BUNDLE_IMG_BASE=$IMAGE-bundle
 CATALOG_IMG_BASE=$IMAGE-catalog


### PR DESCRIPTION
Fixes [OCPBUGS-3963](https://issues.redhat.com/browse/OCPBUGS-3963)

@xiaojiey this is how I tested:

1. check out this PR
2. log in to the cluster
3. upload the operator images with `make push-openshift-dev`
4. change the images in the bundle to point to the ones you just pushed to the cluster with `sed -i "s#k8s.gcr.io/security-profiles-operator/security-profiles-operator:v0.5.0.*#image-registry.openshift-image-registry.svc:5000/openshift/security-profiles-operator:latest#g" bundle/manifests/security-profiles-operator.clusterserviceversion.yaml`
5. build the bundle, then push the result. I used `make bundle-build BUNDLE_IMG=quay.io/jhrozek/security-profiles-operator-bundle:all_namespaces-backport`
6. build the catalog, then push the result. I used `make catalog-build BUNDLE_IMGS=quay.io/jhrozek/security-profiles-operator-bundle:all_namespaces-backport CATALOG_IMG=quay.io/jhrozek/security-profiles-operator-catalog:all_namespaces-backport`
7. Now you can test any installation method as per the OLM docs and they should work. You can even use the images from the examples above, they are built from this PR's branch.

For all installation methods, you can use the same catalog:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: security-profiles-operator
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/jhrozek/security-profiles-operator-catalog:all_namespaces-backport
```

Some examples I tried:
```
apiVersion: operators.coreos.com/v1alpha2
kind: OperatorGroup
metadata:
  name: spo-single-namespace
  namespace: spo-lives-here
spec:
  targetNamespaces:
  - spo-test
```
together with:
```
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: security-profiles-operator-sub
  namespace: spo-lives-here
spec:
  channel: stable
  name: security-profiles-operator
  source: security-profiles-operator
  sourceNamespace: openshift-marketplace
```

This is the default installation method we should be using in our tests:
```
apiVersion: operators.coreos.com/v1
kind: OperatorGroup
metadata:
  name: spo-all-namespaces
  namespace: security-profiles-operator
```
and then a simple sub:
```
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: security-profiles-operator-sub
  namespace: security-profiles-operator
spec:
  channel: stable
  name: security-profiles-operator
  source: security-profiles-operator
  sourceNamespace: openshift-marketplace
```

The only difference in downstream (after this patch merges) is that we would use `openshift-security-profiles` as the NS, not `security-profiles-operator`.