### PR TITLE
OCPBUGS-3690: profilerecorder: gracefully skip containers that did not record anything

### DIFF
--- a/internal/pkg/daemon/enricher/grpc.go
+++ b/internal/pkg/daemon/enricher/grpc.go
@@ -22,10 +22,19 @@ import (
 	"fmt"
 	"runtime"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	api "sigs.k8s.io/security-profiles-operator/api/grpc/enricher"
+)
+
+const (
+	// ErrorNoSyscalls is returned when no syscalls are recorded for a profile.
+	ErrorNoSyscalls = "no syscalls recorded for profile"
+	// ErrorNoAvcs is returned when no AVCs are recorded for a profile.
+	ErrorNoAvcs = "no avcs recorded for profile"
 )
 
 // Syscalls returns the syscalls for a provided profile.
@@ -34,9 +43,8 @@ func (e *Enricher) Syscalls(
 ) (*api.SyscallsResponse, error) {
 	syscalls, ok := e.syscalls.Load(r.GetProfile())
 	if !ok {
-		return nil, fmt.Errorf(
-			"no syscalls recorded for profile: %v", r.GetProfile(),
-		)
+		st := status.New(codes.NotFound, ErrorNoSyscalls)
+		return nil, st.Err()
 	}
 	stringSet, ok := syscalls.(sets.String)
 	if !ok {
@@ -62,9 +70,8 @@ func (e *Enricher) Avcs(
 ) (*api.AvcResponse, error) {
 	avcs, ok := e.avcs.Load(r.GetProfile())
 	if !ok {
-		return nil, fmt.Errorf(
-			"no avcs recorded for profile: %v", r.GetProfile(),
-		)
+		st := status.New(codes.NotFound, ErrorNoAvcs)
+		return nil, st.Err()
 	}
 
 	avcList := make([]*api.AvcResponse_SelinuxAvc, 0)

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -30,7 +30,8 @@ import (
 	"github.com/containers/common/pkg/seccomp"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/go-logr/logr"
-	"google.golang.org/grpc/status"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,6 +55,7 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/controller"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/bpfrecorder"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/enricher"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/metrics"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/webhooks/utils"
 )
@@ -472,6 +474,14 @@ func (r *RecorderReconciler) collectLogSeccompProfile(
 	request := &enricherapi.SyscallsRequest{Profile: profileID}
 	response, err := r.Syscalls(ctx, enricherClient, request)
 	if err != nil {
+		if grpcstatus.Convert(err).Code() == grpccodes.NotFound &&
+			grpcstatus.Convert(err).Message() == enricher.ErrorNoSyscalls {
+			if err := r.ResetSyscalls(ctx, enricherClient, request); err != nil {
+				return fmt.Errorf("reset syscalls for profile %s: %w", profileNamespacedName, err)
+			}
+			r.log.Info("No syscalls found, resetting profile", "profileID", profileID)
+			return nil
+		}
 		return fmt.Errorf("retrieve syscalls for profile %s: %w", profileID, err)
 	}
 
@@ -553,6 +563,14 @@ func (r *RecorderReconciler) collectLogSelinuxProfile(
 	request := &enricherapi.AvcRequest{Profile: profileID}
 	response, err := r.Avcs(ctx, enricherClient, request)
 	if err != nil {
+		if grpcstatus.Convert(err).Code() == grpccodes.NotFound &&
+			grpcstatus.Convert(err).Message() == enricher.ErrorNoAvcs {
+			if err := r.ResetAvcs(ctx, enricherClient, request); err != nil {
+				return fmt.Errorf("reset selinuxprofile for profile %s: %w", profileNamespacedName, err)
+			}
+			r.log.Info("No AVCs found, resetting profile", "profileID", profileID)
+			return nil
+		}
 		return fmt.Errorf("retrieve avcs for profile %s: %w", profileID, err)
 	}
 
@@ -673,7 +691,7 @@ func (r *RecorderReconciler) collectBpfProfiles(
 			// PID was not found for this profile, this might be an init container
 			// which is not longer active. Let's skip here and keep processing the
 			// next profile.
-			if status.Convert(err).Message() == bpfrecorder.ErrNotFound.Error() {
+			if grpcstatus.Convert(err).Message() == bpfrecorder.ErrNotFound.Error() {
 				r.log.Error(err, "Recorded profile not found", "name", profile.name)
 				continue
 			} else {

--- a/test/tc_bpf_recorder_test.go
+++ b/test/tc_bpf_recorder_test.go
@@ -119,6 +119,7 @@ func (e *e2e) testCaseBpfRecorderMultiContainer() {
 
 	const profileNameRedis = recordingName + "-redis"
 	const profileNameNginx = recordingName + "-nginx"
+	const profileNameInit = recordingName + "-init"
 	e.waitForBpfRecorderLogs(since, profileNameRedis, profileNameNginx)
 
 	e.kubectl("delete", "pod", podName)
@@ -129,8 +130,11 @@ func (e *e2e) testCaseBpfRecorderMultiContainer() {
 	profileNginx := e.retryGetSeccompProfile(profileNameNginx)
 	e.Contains(profileNginx, "close")
 
+	profileInit := e.retryGetSeccompProfile(profileNameInit)
+	e.Contains(profileInit, "write")
+
 	e.kubectl("delete", "-f", exampleRecordingBpfPath)
-	e.kubectl("delete", "sp", profileNameRedis, profileNameNginx)
+	e.kubectl("delete", "sp", profileNameRedis, profileNameNginx, profileNameInit)
 }
 
 func (e *e2e) testCaseBpfRecorderDeployment() {
@@ -292,6 +296,10 @@ func (e *e2e) testCaseBpfRecorderSelectContainer() {
 
 	const profileNameRedis = recordingName + "-redis"
 	exists := e.existsSeccompProfile(profileNameRedis)
+	e.False(exists)
+
+	const profileNameInit = recordingName + "-init"
+	exists = e.existsSeccompProfile(profileNameInit)
 	e.False(exists)
 
 	e.kubectl("delete", "-f", exampleRecordingBpfSpecificContainerPath)

--- a/test/tc_profilerecordings_test.go
+++ b/test/tc_profilerecordings_test.go
@@ -195,6 +195,10 @@ func (e *e2e) profileRecordingSelinuxMultiContainer(
 	nginxpathresult := e.retryGetSelinuxJsonpath("{.spec.allow.http_cache_port_t.tcp_socket}", profileNameNginx)
 	e.Contains(nginxpathresult, "name_bind")
 
+	const profileNameInit = recordingName + "-init"
+	exists := e.existsSelinuxProfile(profileNameInit)
+	e.False(exists)
+
 	e.kubectl("delete", "-f", recording)
 	e.kubectl("delete", "selinuxprofile", profileNameRedis, profileNameNginx)
 }
@@ -221,8 +225,12 @@ func (e *e2e) profileRecordingMultiContainer(
 	profileNginx := e.retryGetSeccompProfile(profileNameNginx)
 	e.Contains(profileNginx, "close")
 
+	const profileNameInit = recordingName + "-init"
+	profileInit := e.retryGetSeccompProfile(profileNameInit)
+	e.Contains(profileInit, "write")
+
 	e.kubectl("delete", "-f", recording)
-	e.kubectl("delete", "sp", profileNameRedis, profileNameNginx)
+	e.kubectl("delete", "sp", profileNameRedis, profileNameNginx, profileNameInit)
 }
 
 func (e *e2e) profileRecordingSpecificContainer(
@@ -245,6 +253,10 @@ func (e *e2e) profileRecordingSpecificContainer(
 
 	const profileNameRedis = recordingName + "-redis"
 	exists := e.existsSeccompProfile(profileNameRedis)
+	e.False(exists)
+
+	const profileNameInit = recordingName + "-init"
+	exists = e.existsSeccompProfile(profileNameInit)
 	e.False(exists)
 
 	e.kubectl("delete", "-f", recording)
@@ -448,6 +460,10 @@ func (e *e2e) existsSeccompProfile(args ...string) bool {
 	return e.exists(append([]string{"sp"}, args...)...)
 }
 
+func (e *e2e) existsSelinuxProfile(args ...string) bool {
+	return e.exists(append([]string{"selinuxprofile"}, args...)...)
+}
+
 func (e *e2e) retryGetSelinuxJsonpath(jsonpath string, args ...string) string {
 	jsonpatharg := fmt.Sprintf("jsonpath=%s", jsonpath)
 	return e.retryGet(append([]string{"selinuxprofile", "-o", jsonpatharg}, args...)...)
@@ -507,6 +523,9 @@ metadata:
   labels:
     app: alpine
 spec:
+  initContainers:
+  - image: quay.io/security-profiles-operator/test-hello-world:latest
+    name: init
   containers:
   - name: nginx
     image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21

--- a/test/tc_seccomp_profilebindings_test.go
+++ b/test/tc_seccomp_profilebindings_test.go
@@ -63,6 +63,7 @@ spec:
 
 	e.kubectl("create", "-f", exampleProfilePath)
 	defer e.kubectl("delete", "-f", exampleProfilePath)
+	e.waitFor("condition=ready", "seccompprofile", "profile-allow-unsafe")
 
 	e.logf("Creating test profile binding")
 	testBindingFile, err := os.CreateTemp("", "hello-binding*.yaml")


### PR DESCRIPTION
Backports https://github.com/kubernetes-sigs/security-profiles-operator/pull/1378 which fixes https://issues.redhat.com/browse/OCPBUGS-3690

It's unusual to send a backport before an upstream patch is merged, but I'm doing that because:

- the holiday season starts soon and reviews might take longer
- the upstream CI tests that run the upstream e2e tests on Flatcar are not working at the moment which is blocking merges upstram
- I want to get the PR through the OCP CI to see if there's any failures
- I want to give QE a head start testing the PR

We can
/hold
the PR until the original upstream PR is reviewed and merged.