### PR TITLE
OCPBUGS-4976: bundle: Add OCP-specific cluster monitoring annotation

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -99,6 +99,7 @@ metadata:
     capabilities: Basic Install
     categories: Security
     olm.skipRange: '>=0.4.1 <0.5.0'
+    operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: security-profiles-operator
     operators.operatorframework.io/builder: operator-sdk-v1.22.2
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift

--- a/deploy/base/clusterserviceversion.yaml
+++ b/deploy/base/clusterserviceversion.yaml
@@ -9,6 +9,7 @@ metadata:
     olm.skipRange: '>=0.4.1 <0.4.2-dev'
     operatorframework.io/suggested-namespace: security-profiles-operator
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+    operatorframework.io/cluster-monitoring: "true"
   name: security-profiles-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
Note that the bundle must list the suggested namespace as `openshift-security-profiles` which is not the case with upstream bundles, we change the suggested namespace downstream.
For testing, I prepared a bundle and a catalog which you can enable with:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: security-profiles-operator
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/jhrozek/security-profiles-operator-catalog:ns-monitoring-2
```