### PR TITLE
Update bundle CSV to match 0.5.2 tag

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -98,14 +98,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Security
-    olm.skipRange: '>=0.4.1 <0.5.0'
+    olm.skipRange: '>=0.4.1 <0.5.2'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: security-profiles-operator
     operators.operatorframework.io/builder: operator-sdk-v1.22.2
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
       Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: security-profiles-operator.v0.5.0
+  name: security-profiles-operator.v0.5.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -818,4 +818,4 @@ spec:
     name: rbac-proxy
   - image: quay.io/security-profiles-operator/selinuxd
     name: selinuxd
-  version: 0.5.0
+  version: 0.5.2


### PR DESCRIPTION
We want to ship 0.5.2 to include some updated dependencies, but we need to make sure the CSV matches the tag so that the version we're trying to build/install (0.5.2) is what we expect and not what's in the current CSV (0.5.0).

This step might have been missed in the last release. Adding it here so things are up-to-date.
