### PR TITLE
Make the selinuxd auto-selection logic use environment variables

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -90,11 +90,11 @@ data:
     [
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
         },
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
         }
     ]
   selinuxd.cil: |

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -856,6 +856,10 @@ spec:
                   value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
                 - name: RELATED_IMAGE_SELINUXD
                   value: quay.io/security-profiles-operator/selinuxd
+                - name: RELATED_IMAGE_SELINUXD_EL8
+                  value: quay.io/security-profiles-operator/selinuxd-el8:latest
+                - name: RELATED_IMAGE_SELINUXD_EL9
+                  value: quay.io/security-profiles-operator/selinuxd-el9:latest
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -976,5 +980,9 @@ spec:
     name: rbac-proxy
   - image: quay.io/security-profiles-operator/selinuxd
     name: selinuxd
+  - image: quay.io/security-profiles-operator/selinuxd-el8:latest
+    name: selinuxd-el8
+  - image: quay.io/security-profiles-operator/selinuxd-el9:latest
+    name: selinuxd-el9
   replaces: security-profiles-operator.v0.7.0
   version: 0.7.1

--- a/deploy/base/profiles/selinuxd-image-mapping.json
+++ b/deploy/base/profiles/selinuxd-image-mapping.json
@@ -1,10 +1,10 @@
 [
     {
         "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-        "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+        "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
     },
     {
         "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
-        "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+        "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
     }
 ]

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
           value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
+        - name: RELATED_IMAGE_SELINUXD_EL8
+          value: quay.io/security-profiles-operator/selinuxd-el8:latest
+        - name: RELATED_IMAGE_SELINUXD_EL9
+          value: quay.io/security-profiles-operator/selinuxd-el9:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -966,11 +966,11 @@ data:
     [
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
         },
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
         }
     ]
   selinuxd.cil: |

--- a/deploy/kustomize-deployment/manager_deployment.yaml
+++ b/deploy/kustomize-deployment/manager_deployment.yaml
@@ -38,6 +38,10 @@ spec:
               value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
             - name: RELATED_IMAGE_SELINUXD
               value: quay.io/security-profiles-operator/selinuxd
+            - name: RELATED_IMAGE_SELINUXD_EL8
+              value: quay.io/security-profiles-operator/selinuxd-el8:latest
+            - name: RELATED_IMAGE_SELINUXD_EL9
+              value: quay.io/security-profiles-operator/selinuxd-el9:latest
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2920,11 +2920,11 @@ data:
     [
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
         },
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
         }
     ]
   selinuxd.cil: |
@@ -3012,6 +3012,10 @@ spec:
           value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
+        - name: RELATED_IMAGE_SELINUXD_EL8
+          value: quay.io/security-profiles-operator/selinuxd-el8:latest
+        - name: RELATED_IMAGE_SELINUXD_EL9
+          value: quay.io/security-profiles-operator/selinuxd-el9:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2902,11 +2902,11 @@ data:
     [
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
         },
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
         }
     ]
   selinuxd.cil: |
@@ -3003,6 +3003,10 @@ spec:
           value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
+        - name: RELATED_IMAGE_SELINUXD_EL8
+          value: quay.io/security-profiles-operator/selinuxd-el8:latest
+        - name: RELATED_IMAGE_SELINUXD_EL9
+          value: quay.io/security-profiles-operator/selinuxd-el9:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2933,11 +2933,11 @@ data:
     [
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
         },
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
         }
     ]
   selinuxd.cil: |
@@ -3023,6 +3023,10 @@ spec:
           value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
+        - name: RELATED_IMAGE_SELINUXD_EL8
+          value: quay.io/security-profiles-operator/selinuxd-el8:latest
+        - name: RELATED_IMAGE_SELINUXD_EL9
+          value: quay.io/security-profiles-operator/selinuxd-el9:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2920,11 +2920,11 @@ data:
     [
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
         },
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
         }
     ]
   selinuxd.cil: |
@@ -3010,6 +3010,10 @@ spec:
           value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
+        - name: RELATED_IMAGE_SELINUXD_EL8
+          value: quay.io/security-profiles-operator/selinuxd-el8:latest
+        - name: RELATED_IMAGE_SELINUXD_EL9
+          value: quay.io/security-profiles-operator/selinuxd-el9:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2891,11 +2891,11 @@ data:
     [
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
         },
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
-            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
         }
     ]
   selinuxd.cil: |
@@ -3010,6 +3010,10 @@ spec:
           value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
+        - name: RELATED_IMAGE_SELINUXD_EL8
+          value: quay.io/security-profiles-operator/selinuxd-el8:latest
+        - name: RELATED_IMAGE_SELINUXD_EL9
+          value: quay.io/security-profiles-operator/selinuxd-el9:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/internal/pkg/manager/spod/setup.go
+++ b/internal/pkg/manager/spod/setup.go
@@ -163,11 +163,13 @@ func (r *ReconcileSPOd) getSelinuxdImage(ctx context.Context, node *corev1.Node)
 	}
 	selinuxdImageMapping := operatorCm.Data[util.SelinuxdImageMappingKey]
 
-	selinuxdImage, err := util.MatchSelinuxdImageJSONMapping(node, []byte(selinuxdImageMapping))
+	selinuxdImageEnvVar, err := util.MatchSelinuxdImageJSONMapping(node, []byte(selinuxdImageMapping))
 	if err != nil {
 		return "", fmt.Errorf("matching selinuxd image: %w", err)
 	}
 
+	// not checking selinuxdImageEnvVar is fine here as os.Getenv returns an empty string in that case
+	selinuxdImage := os.Getenv(selinuxdImageEnvVar)
 	if selinuxdImage != "" {
 		r.log.Info("matched selinuxd image against nodeInfo", "image", selinuxdImage)
 		return selinuxdImage, nil

--- a/internal/pkg/util/kubernetes.go
+++ b/internal/pkg/util/kubernetes.go
@@ -96,8 +96,8 @@ func GetKubeletDirFromNodeLabel(ctx context.Context, c client.Reader) (string, e
 }
 
 type selinuxdImageMap struct {
-	Regex string `json:"regex"`
-	Image string `json:"image"`
+	Regex        string `json:"regex"`
+	ImageFromVar string `json:"imageFromVar"`
 }
 
 func MatchSelinuxdImageJSONMapping(node *corev1.Node, mappingObj []byte) (string, error) {
@@ -120,7 +120,7 @@ func matchSelinuxdImage(node *corev1.Node, mapping []selinuxdImageMap) string {
 			continue
 		}
 		if matched, err := regexp.MatchString(m.Regex, node.Status.NodeInfo.OSImage); err == nil && matched {
-			return m.Image
+			return m.ImageFromVar
 		}
 	}
 

--- a/internal/pkg/util/kubernetes_test.go
+++ b/internal/pkg/util/kubernetes_test.go
@@ -172,11 +172,11 @@ func TestMatchSelinuxdImageVersion(t *testing.T) {
 	mappingJSON := `[
 		{
 			"regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-			"image":"quay.io/security-profiles-operator/selinuxd:el8"
+			"imageFromVar":"RELATED_IMAGE_RHEL8_SELINUXD"
 		},
 		{
 			"regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
-			"image":"quay.io/security-profiles-operator/selinuxd:el9"
+			"imageFromVar":"RELATED_IMAGE_RHEL9_SELINUXD"
 		}
 	]`
 
@@ -194,7 +194,7 @@ func TestMatchSelinuxdImageVersion(t *testing.T) {
 					},
 				},
 			},
-			want: "quay.io/security-profiles-operator/selinuxd:el8",
+			want: "RELATED_IMAGE_RHEL8_SELINUXD",
 		},
 		{
 			name: "Should return el9",
@@ -205,7 +205,7 @@ func TestMatchSelinuxdImageVersion(t *testing.T) {
 					},
 				},
 			},
-			want: "quay.io/security-profiles-operator/selinuxd:el9",
+			want: "RELATED_IMAGE_RHEL9_SELINUXD",
 		},
 		{
 			name: "Does not match anything",


### PR DESCRIPTION
This patch doesn't change the functionality in any way whatsoever, but makes it easier for tools that reason about bundle or helm manifests to do their job.

I hit such issue with a tool we use in OpenShift that was not able to detect that I forgot to rewrite the quay.io upstream images in the configMap to our downstream images.

We used to put the mapping between selinuxd images and OS directly into a configmap. This is problematic for the aforementioned tools as a container pullspec is hard to find in operator manifests. To make their job easier, the configmap now points to an environment variable name that is defined in the operator deployment manifest.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
