### PR TITLE
Use kube-rbac-proxy v0.15.0 and disable HTTP/2

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -853,7 +853,7 @@ spec:
                 - manager
                 env:
                 - name: RELATED_IMAGE_RBAC_PROXY
-                  value: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+                  value: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
                 - name: RELATED_IMAGE_SELINUXD
                   value: quay.io/security-profiles-operator/selinuxd
                 - name: RELATED_IMAGE_SELINUXD_EL8
@@ -977,7 +977,7 @@ spec:
     name: Kubernetes SIGs
     url: https://github.com/kubernetes-sigs
   relatedImages:
-  - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+  - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
     name: rbac-proxy
   - image: quay.io/security-profiles-operator/selinuxd
     name: selinuxd

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -136,7 +136,7 @@ dependencies:
       match: NIX_VERSION
 
   - name: kube-rbac-proxy
-    version: 0.14.0
+    version: 0.15.0
     refPaths:
     - path: internal/pkg/manager/spod/bindata/spod.go
       match: gcr.io/kubebuilder/kube-rbac-proxy

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: RELATED_IMAGE_SELINUXD_EL8

--- a/deploy/kustomize-deployment/manager_deployment.yaml
+++ b/deploy/kustomize-deployment/manager_deployment.yaml
@@ -36,7 +36,7 @@ spec:
               cpu: 500m
           env:
             - name: RELATED_IMAGE_RBAC_PROXY
-              value: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+              value: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
             - name: RELATED_IMAGE_SELINUXD
               value: quay.io/security-profiles-operator/selinuxd
             - name: RELATED_IMAGE_SELINUXD_EL8

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3023,7 +3023,7 @@ spec:
         - name: RESTRICT_TO_NAMESPACE
           value: NS_REPLACE
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: RELATED_IMAGE_SELINUXD_EL8

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3014,7 +3014,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: RELATED_IMAGE_SELINUXD_EL8

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3034,7 +3034,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: RELATED_IMAGE_SELINUXD_EL8

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3021,7 +3021,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: RELATED_IMAGE_SELINUXD_EL8

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3021,7 +3021,7 @@ spec:
         - --webhook=false
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: RELATED_IMAGE_SELINUXD_EL8

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -55,7 +55,7 @@ const (
 	SelinuxdPrivateDir                         = "/var/run/selinuxd"
 	SelinuxdSocketPath                         = SelinuxdPrivateDir + "/selinuxd.sock"
 	SelinuxdDBPath                             = SelinuxdPrivateDir + "/selinuxd.db"
-	MetricsImage                               = "gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0"
+	MetricsImage                               = "gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0"
 	sysKernelDebugPath                         = "/sys/kernel/debug"
 	InitContainerIDNonRootenabler              = 0
 	InitContainerIDSelinuxSharedPoliciesCopier = 1
@@ -608,6 +608,7 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 							"--v=10",
 							fmt.Sprintf("--tls-cert-file=%s", filepath.Join(metricsCertPath, "tls.crt")),
 							fmt.Sprintf("--tls-private-key-file=%s", filepath.Join(metricsCertPath, "tls.key")),
+							"--http2-disable",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{


### PR DESCRIPTION
Disabling HTTP/2 mitigates a rapid reset vulnerability in HTTP/2 protocol.

