### PR TITLE
Isolate OpenShift maintainer commits from main branch

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,7 +10,7 @@ approvers:
   - sheriff-rh
   - Vincent056
   - xiaojiey
-  - Wiharris
+  - BhargaviGudi
 emeritus_approvers:
   - cmurphy
   - hasheddan

--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@
 reviewers:
   - Vincent056
 approvers:
-  - ccojocar
   - pjbgf
   - saschagrunert
   - JAORMX

--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,10 @@ approvers:
   - saschagrunert
   - JAORMX
   - jhrozek
+  - sheriff-rh
+  - Vincent056
+  - xiaojiey
+  - Wiharris
 emeritus_approvers:
   - cmurphy
   - hasheddan


### PR DESCRIPTION
Include OpenShift maintainer commits in their own OCP branch.

Ideally, this will be rebased on top of the main branch periodically when we do releases.