### PR TITLE
Set `ocp` branch to use the correct commit for tag 0.8.1

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,7 +10,7 @@ approvers:
   - sheriff-rh
   - Vincent056
   - xiaojiey
-  - Wiharris
+  - BhargaviGudi
 emeritus_approvers:
   - cmurphy
   - hasheddan

--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@
 reviewers:
   - Vincent056
 approvers:
-  - ccojocar
   - pjbgf
   - saschagrunert
   - JAORMX

--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,10 @@ approvers:
   - saschagrunert
   - JAORMX
   - jhrozek
+  - sheriff-rh
+  - Vincent056
+  - xiaojiey
+  - Wiharris
 emeritus_approvers:
   - cmurphy
   - hasheddan


### PR DESCRIPTION
Update the OCP branch to only contain the changes necessary for the Prow CI to work.

This also branches the `ocp` branch from the 0.8.1 tagged commit, instead of the latest main from upstream, which is already using the 0.8.2-dev version.