### PR TITLE
OCPBUGS-49336 - Add security profiles operator documentation link for Security Profiles Operator bundle

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -970,7 +970,7 @@ spec:
   - name: Security Profiles Operator
     url: https://github.com/kubernetes-sigs/security-profiles-operator
   - name: Security Profiles Operator documentation
-    url: https://docs.openshift.com/container-platform/latest/security/security_profiles_operator/spo-understanding.html
+    url: https://docs.openshift.com/container-platform/latest/security/security_profiles_operator/spo-overview.html
   maintainers:
   - email: dev@kubernetes.io
     name: Kubernetes upstream

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -969,6 +969,8 @@ spec:
   links:
   - name: Security Profiles Operator
     url: https://github.com/kubernetes-sigs/security-profiles-operator
+  - name: Security Profiles Operator documentation
+    url: https://docs.openshift.com/container-platform/latest/security/security_profiles_operator/spo-understanding.html
   maintainers:
   - email: dev@kubernetes.io
     name: Kubernetes upstream

--- a/deploy/base/clusterserviceversion.yaml
+++ b/deploy/base/clusterserviceversion.yaml
@@ -82,6 +82,8 @@ spec:
   links:
   - name: Security Profiles Operator
     url: https://github.com/kubernetes-sigs/security-profiles-operator
+  - name: Security Profiles Operator documentation
+    url: https://docs.openshift.com/container-platform/latest/security/security_profiles_operator/spo-understanding.html
   maintainers:
   - email: dev@kubernetes.io
     name: Kubernetes upstream

--- a/deploy/base/clusterserviceversion.yaml
+++ b/deploy/base/clusterserviceversion.yaml
@@ -83,7 +83,7 @@ spec:
   - name: Security Profiles Operator
     url: https://github.com/kubernetes-sigs/security-profiles-operator
   - name: Security Profiles Operator documentation
-    url: https://docs.openshift.com/container-platform/latest/security/security_profiles_operator/spo-understanding.html
+    url: https://docs.openshift.com/container-platform/latest/security/security_profiles_operator/spo-overview.html
   maintainers:
   - email: dev@kubernetes.io
     name: Kubernetes upstream


### PR DESCRIPTION
This commit adds the  security profiles operator documentation reference link in Security Profiles operator bundle which should fix [OCPBUGS-49336](https://issues.redhat.com/browse/OCPBUGS-49336)

PR is tested and verified.
Security profiles operator documentation reference: https://docs.openshift.com/container-platform/latest/security/security_profiles_operator/spo-overview.html 
