### PR TITLE
OCPBUGS-49401 - Update the name of the Security Profiles Operator upstream repository in the Security Profiles Operator bundle

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -967,7 +967,7 @@ spec:
   - apparmor
   - ebpf
   links:
-  - name: Security Profiles Operator
+  - name: Security Profiles Operator upstream repository
     url: https://github.com/kubernetes-sigs/security-profiles-operator
   maintainers:
   - email: dev@kubernetes.io

--- a/deploy/base/clusterserviceversion.yaml
+++ b/deploy/base/clusterserviceversion.yaml
@@ -80,7 +80,7 @@ spec:
   - apparmor
   - ebpf
   links:
-  - name: Security Profiles Operator
+  - name: Security Profiles Operator upstream repository
     url: https://github.com/kubernetes-sigs/security-profiles-operator
   maintainers:
   - email: dev@kubernetes.io


### PR DESCRIPTION
This commit updates the name to `Security Profiles Operator upstream repository` under `Links` for better readability which should fix [OCPBUGS-49401](https://issues.redhat.com/browse/OCPBUGS-49401)