### PR TITLE
Fix SPO dockerfile and update annotation script with correct name

### DIFF
--- a/bundle-hack/update_bundle_annotations.sh
+++ b/bundle-hack/update_bundle_annotations.sh
@@ -15,7 +15,7 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: compliance-operator
+  operators.operatorframework.io.bundle.package.v1: security-profiles-operator
 EOM
 )
 echo "$ANNOTATIONS_CONTENT" > ../bundle/metadata/annotations.yaml

--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -11,7 +11,7 @@ RUN ./update_bundle_namespace.sh
 RUN ./update_bundle_rbac.sh
 
 FROM scratch
-LABEL name=openshift-compliance-operator-bundle
+LABEL name=security-profiles-operator-bundle
 LABEL version=${SPO_VERSION}
 LABEL summary='OpenShift Security Profiles Operator'
 LABEL maintainer='Infrastructure Security and Compliance Team <isc-team@redhat.com>'


### PR DESCRIPTION
Rename compliance operator bundle to security profiles operator bundle in Dockerfile and update corresponding annotations in the update_bundle_annotations script.
