### PR TITLE
Add required labels for Power architecture support in update_csv.go

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -35,7 +35,9 @@ LABEL \
         com.redhat.component="openshift-security-profiles-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Security Profiles Operator" \
-        version=0.8.4
+        description="The Security Profiles Operator makes it easier for cluster admins to manage their seccomp, or SELinux profiles and apply them to Kubernetes workloads." \
+        summary="Security Profiles Operator" \
+        version=0.9.0
 #        io.openshift.build.commit.id=98271bc2812881010146f47e4587dcd449b846bd \
 #        io.openshift.build.source-location=https://github.com/openshift/file-integrity-operator.git \
 #        io.openshift.build.commit.url=https://github.com/openshift/file-integrity-operator.git/commit/98271bc2812881010146f47e4587dcd449b846bd \

--- a/bundle-hack/update_csv.go
+++ b/bundle-hack/update_csv.go
@@ -323,9 +323,9 @@ func updateRelatedImages(m map[string]interface{}, defs []imgDef) error {
 	envToRelatedName := map[string]string{
 		"RELATED_IMAGE_OPERATOR":        "security-profiles-operator",
 		"RELATED_IMAGE_SELINUXD":        "selinuxd",
-		"RELATED_IMAGE_SELINUXD_EL8":    "selinuxd_el8",
-		"RELATED_IMAGE_SELINUXD_EL9":    "selinuxd_el9",
-		"RELATED_IMAGE_SELINUXD_FEDORA": "selinuxd_fedora",
+		"RELATED_IMAGE_SELINUXD_EL8":    "selinuxd-el8",
+		"RELATED_IMAGE_SELINUXD_EL9":    "selinuxd-el9",
+		"RELATED_IMAGE_SELINUXD_FEDORA": "selinuxd-fedora",
 	}
 
 	// Build the image map

--- a/bundle-hack/update_csv.go
+++ b/bundle-hack/update_csv.go
@@ -134,7 +134,8 @@ func addRequiredAnnotations(m map[string]interface{}) error {
 // addRequiredLabels adds required labels under metadata.labels
 func addRequiredLabels(m map[string]interface{}) error {
 	requiredLabels := map[string]string{
-		"operatorframework.io/arch.amd64": "supported",
+		"operatorframework.io/arch.amd64":   "supported",
+		"operatorframework.io/arch.ppc64le": "supported",
 	}
 
 	metadata, ok := m["metadata"].(map[string]interface{})


### PR DESCRIPTION
This commit adds a new label for the ppc64le architecture to the existing required labels in the addRequiredLabels function
