### PR TITLE
Sync image sha256

### DIFF
--- a/bundle-hack/update_csv.go
+++ b/bundle-hack/update_csv.go
@@ -196,7 +196,7 @@ func replaceImages(m map[string]interface{}) error {
 	defs := []imgDef{
 		{
 			EnvName:    "RELATED_IMAGE_OPERATOR",
-			KonfluxPS:  "quay.io/redhat-user-workloads/ocp-isc-tenant/security-profiles-operator-release@sha256:779836f8dd4ba501b8bf8b8f0b89f0f6f5280904f546357006259f4d2b39accb",
+			KonfluxPS:  "quay.io/redhat-user-workloads/ocp-isc-tenant/security-profiles-operator-release@sha256:78d85ef076692d2f6ac31eb9ce451f2b7c058635f4184e831c9c4672138d7a2b",
 			RedHatBase: "registry.redhat.io/compliance/openshift-security-profiles-rhel8-operator",
 		},
 		{


### PR DESCRIPTION
sync update_csv.go to use quay.io/redhat-user-workloads/ocp-isc-tenant/security-profiles-operator-release@sha256:78d85ef076692d2f6ac31eb9ce451f2b7c058635f4184e831c9c4672138d7a2b

```
  {
    "componentName": "security-profiles-operator-release-0-9",
    "application": "security-profiles-operator-release-0-9",
    "containerImage": "quay.io/redhat-user-workloads/ocp-isc-tenant/security-profiles-operator-release",
    "lastBuiltCommit": "e9d162a91b2cd0c3b32f8b62fd8df09146d0f0be",
    "lastPromotedImage": "quay.io/redhat-user-workloads/ocp-isc-tenant/security-profiles-operator-release@sha256:78d85ef076692d2f6ac31eb9ce451f2b7c058635f4184e831c9c4672138d7a2b",
    "lastPromotedImageCreatedAt": "2025-07-11T15:18:33.047513695Z",
  }
```
