### PR TITLE
 OCPBUGS-55829: SELinuxd image mapping regex

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -263,11 +263,11 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux release)\\s+8\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux release)\\s+9\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {

--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -263,16 +263,16 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {
-            "regex":"Fedora \\d+",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
+            "regex": "Fedora \\d+",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |

--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -193,6 +193,7 @@ data:
             "capget",
             "capset",
             "chdir",
+            "clone",
             "clone3",
             "close",
             "connect",

--- a/deploy/base/profiles/selinuxd-image-mapping.json
+++ b/deploy/base/profiles/selinuxd-image-mapping.json
@@ -1,10 +1,10 @@
 [
     {
-        "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+        "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux release)\\s+8\\.[0-9]+",
         "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
     },
     {
-        "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+        "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux release)\\s+9\\.[0-9]+",
         "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
     },
     {

--- a/deploy/base/profiles/selinuxd-image-mapping.json
+++ b/deploy/base/profiles/selinuxd-image-mapping.json
@@ -1,14 +1,14 @@
 [
     {
-        "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-        "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
+        "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+        "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
     },
     {
-        "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)|(.*)(CoreOS)([\\s+])9\\.(.*)",
-        "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+        "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+        "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
     },
     {
-        "regex":"Fedora \\d+",
-        "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
+        "regex": "Fedora \\d+",
+        "imageFromVar": "RELATED_IMAGE_SELINUXD_FEDORA"
     }
 ]

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -951,16 +951,16 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)|(.*)(CoreOS)([\\s+])9\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {
-            "regex":"Fedora \\d+",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
+            "regex": "Fedora \\d+",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -951,11 +951,11 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux release)\\s+8\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux release)\\s+9\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3234,11 +3234,11 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux release)\\s+8\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux release)\\s+9\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3234,16 +3234,16 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)|(.*)(CoreOS)([\\s+])9\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {
-            "regex":"Fedora \\d+",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
+            "regex": "Fedora \\d+",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3216,16 +3216,16 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)|(.*)(CoreOS)([\\s+])9\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {
-            "regex":"Fedora \\d+",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
+            "regex": "Fedora \\d+",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3146,6 +3146,7 @@ data:
             "capget",
             "capset",
             "chdir",
+            "clone",
             "clone3",
             "close",
             "connect",

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3216,11 +3216,11 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux release)\\s+8\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux release)\\s+9\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3247,16 +3247,16 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)|(.*)(CoreOS)([\\s+])9\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {
-            "regex":"Fedora \\d+",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
+            "regex": "Fedora \\d+",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3247,11 +3247,11 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux release)\\s+8\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux release)\\s+9\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3234,11 +3234,11 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux release)\\s+8\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux release)\\s+9\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3234,16 +3234,16 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)|(.*)(CoreOS)([\\s+])9\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {
-            "regex":"Fedora \\d+",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
+            "regex": "Fedora \\d+",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3205,11 +3205,11 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux release)\\s+8\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux release)\\s+9\\.[0-9]+",
             "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3205,16 +3205,16 @@ data:
   selinuxd-image-mapping.json: |
     [
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL8"
+            "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
         },
         {
-            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)|(.*)(CoreOS)([\\s+])9\\.(.*)",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+            "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
         },
         {
-            "regex":"Fedora \\d+",
-            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
+            "regex": "Fedora \\d+",
+            "imageFromVar": "RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |

--- a/internal/pkg/util/kubernetes_test.go
+++ b/internal/pkg/util/kubernetes_test.go
@@ -174,12 +174,12 @@ func TestMatchSelinuxdImageVersion(t *testing.T) {
 
 	mappingJSON := `[
 		{
-			"regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
-			"imageFromVar":"RELATED_IMAGE_RHEL8_SELINUXD"
+			"regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+			"imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
 		},
 		{
-			"regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)|(.*)(CoreOS)([\\s+])9\\.(.*)",
-			"imageFromVar":"RELATED_IMAGE_RHEL9_SELINUXD"
+			"regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+			"imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
 		}
 	]`
 
@@ -197,7 +197,7 @@ func TestMatchSelinuxdImageVersion(t *testing.T) {
 					},
 				},
 			},
-			want: "RELATED_IMAGE_RHEL8_SELINUXD",
+			want: "RELATED_IMAGE_SELINUXD_EL8",
 		},
 		{
 			name: "Should return el9",
@@ -208,7 +208,7 @@ func TestMatchSelinuxdImageVersion(t *testing.T) {
 					},
 				},
 			},
-			want: "RELATED_IMAGE_RHEL9_SELINUXD",
+			want: "RELATED_IMAGE_SELINUXD_EL9",
 		},
 		{
 			name: "Does not match anything",
@@ -220,6 +220,41 @@ func TestMatchSelinuxdImageVersion(t *testing.T) {
 				},
 			},
 			want: "",
+		},
+		// Reported issue case
+		{
+			name: "User reported case - RHEL CoreOS 9.6",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						OSImage: "Red Hat Enterprise Linux CoreOS 9.6.20250715-0 (Plow)",
+					},
+				},
+			},
+			want: "RELATED_IMAGE_SELINUXD_EL9",
+		},
+		// Future-proofing tests
+		{
+			name: "Future OCP 4.20 (hypothetical)",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						OSImage: "Red Hat Enterprise Linux CoreOS 420.96.202512011200-0 (Plow)",
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "Direct RHEL 9.8 (future)",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						OSImage: "Red Hat Enterprise Linux CoreOS 9.8.202512011200-0 (Plow)",
+					},
+				},
+			},
+			want: "RELATED_IMAGE_SELINUXD_EL9",
 		},
 	}
 

--- a/internal/pkg/util/kubernetes_test.go
+++ b/internal/pkg/util/kubernetes_test.go
@@ -174,11 +174,11 @@ func TestMatchSelinuxdImageVersion(t *testing.T) {
 
 	mappingJSON := `[
 		{
-			"regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*",
+			"regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux release)\\s+8\\.[0-9]+",
 			"imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
 		},
 		{
-			"regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*",
+			"regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux release)\\s+9\\.[0-9]+",
 			"imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
 		}
 	]`
@@ -255,6 +255,28 @@ func TestMatchSelinuxdImageVersion(t *testing.T) {
 				},
 			},
 			want: "RELATED_IMAGE_SELINUXD_EL9",
+		},
+		{
+			name: "Direct RHEL 9.6 without CoreOS",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						OSImage: "Red Hat Enterprise Linux release 9.6 (Plow)",
+					},
+				},
+			},
+			want: "RELATED_IMAGE_SELINUXD_EL9",
+		},
+		{
+			name: "Direct RHEL 8.6 without CoreOS",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						OSImage: "Red Hat Enterprise Linux release 8.6 (Plow)",
+					},
+				},
+			},
+			want: "RELATED_IMAGE_SELINUXD_EL8",
 		},
 	}
 


### PR DESCRIPTION
Fixed regex issue on OCP4.19 where /etc/os-release has been changed to use RHEL version instead of 4.xx Patterns for CoreOS versions in multiple manifests and tests

clone was removed in https://github.com/openshift/security-profiles-operator/commit/a0ad03d2cdc74d60059d602058a8df9dbb71d02a, but it is needed for selinuxd to work on RHEL8 node
