### PR TITLE
Add support for PPC64LE architecture in security profiles operator 

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -126,7 +126,8 @@ metadata:
           },
           "spec": {
             "architectures": [
-              "SCMP_ARCH_X86_64"
+              "SCMP_ARCH_X86_64",
+              "SCMP_ARCH_PPC64LE"
             ],
             "defaultAction": "SCMP_ACT_LOG",
             "syscalls": [

--- a/examples/seccompprofile.yaml
+++ b/examples/seccompprofile.yaml
@@ -36,6 +36,7 @@ spec:
   defaultAction: SCMP_ACT_LOG
   architectures:
   - SCMP_ARCH_X86_64
+  - SCMP_ARCH_PPC64LE
   syscalls:
   - action: SCMP_ACT_ALLOW
     names:


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This update includes the addition of the PPC64LE architecture to both the CSV and example seccomp profile, pulling in the commit from https://github.com/Vincent056/security-profiles-operator-fbc/pull/1

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
