### PR TITLE
OCPBUGS-60139: Fix selinux profilerecording

### DIFF
--- a/internal/pkg/webhooks/recording/recording.go
+++ b/internal/pkg/webhooks/recording/recording.go
@@ -252,10 +252,10 @@ func (p *podSeccompRecorder) updateSecurityContext(
 	}
 
 	switch pr.Spec.Kind {
-	case profilerecordingv1alpha1.ProfileRecordingKindSeccompProfile,
-		profilerecordingv1alpha1.ProfileRecordingKindSelinuxProfile,
-		profilerecordingv1alpha1.ProfileRecordingKindAppArmorProfile:
+	case profilerecordingv1alpha1.ProfileRecordingKindSeccompProfile:
 		p.updateSeccompSecurityContext(ctr, pr)
+	case profilerecordingv1alpha1.ProfileRecordingKindSelinuxProfile:
+		p.updateSelinuxSecurityContext(ctr, pr)
 	}
 
 	p.log.Info(fmt.Sprintf(
@@ -287,6 +287,26 @@ func (p *podSeccompRecorder) updateSeccompSecurityContext(
 		config.LogEnricherProfile,
 	)
 	ctr.SecurityContext.SeccompProfile.LocalhostProfile = &profile
+}
+
+func (p *podSeccompRecorder) updateSelinuxSecurityContext(
+	ctr *corev1.Container,
+	pr *profilerecordingv1alpha1.ProfileRecording,
+) {
+	if ctr.SecurityContext == nil {
+		ctr.SecurityContext = &corev1.SecurityContext{}
+	}
+
+	if ctr.SecurityContext.SELinuxOptions == nil {
+		ctr.SecurityContext.SELinuxOptions = &corev1.SELinuxOptions{}
+	} else {
+		p.record.Eventf(pr,
+			corev1.EventTypeWarning,
+			"SecurityContextAlreadySet",
+			"Container %s had SecurityContext already set, the profile recorder overwrote it", ctr.Name)
+	}
+
+	ctr.SecurityContext.SELinuxOptions.Type = config.SelinuxPermissiveProfile
 }
 
 func (p *podSeccompRecorder) setRecordingReferences(

--- a/internal/pkg/webhooks/recording/recording.go
+++ b/internal/pkg/webhooks/recording/recording.go
@@ -256,6 +256,8 @@ func (p *podSeccompRecorder) updateSecurityContext(
 		p.updateSeccompSecurityContext(ctr, pr)
 	case profilerecordingv1alpha1.ProfileRecordingKindSelinuxProfile:
 		p.updateSelinuxSecurityContext(ctr, pr)
+	case profilerecordingv1alpha1.ProfileRecordingKindAppArmorProfile:
+		p.updateApparmorSecurityContext(ctr, pr)
 	}
 
 	p.log.Info(fmt.Sprintf(
@@ -307,6 +309,20 @@ func (p *podSeccompRecorder) updateSelinuxSecurityContext(
 	}
 
 	ctr.SecurityContext.SELinuxOptions.Type = config.SelinuxPermissiveProfile
+}
+
+func (p *podSeccompRecorder) updateApparmorSecurityContext(
+	ctr *corev1.Container,
+	pr *profilerecordingv1alpha1.ProfileRecording,
+) {
+	if pr.Spec.Recorder != profilerecordingv1alpha1.ProfileRecorderLogs {
+		return
+	}
+
+	p.record.Eventf(pr,
+		corev1.EventTypeWarning,
+		"AppArmorNotSupported",
+		"AppArmor log-based recording is not supported, container: %s", ctr.Name)
 }
 
 func (p *podSeccompRecorder) setRecordingReferences(


### PR DESCRIPTION
…r seccomp

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


Optionally add one or more of the following kinds if applicable:
/kind regression

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fix profilerecording failed to create selinuxprofiles issue.
With this PR, the selinuxprofile now can be created successfully

% oc get selinuxprofiles                                       
NAME                                   USAGE                                           STATE
spo-recording-hello-openshift-b7sps    spo-recording-hello-openshift-b7sps_.process    Installed
spo-recording-hello-openshift-j2l2g    spo-recording-hello-openshift-j2l2g_.process    Installed
spo-recording-hello-openshift-t78hh    spo-recording-hello-openshift-t78hh_.process    Installed
spo-recording-hello-openshift2-b7sps   spo-recording-hello-openshift2-b7sps_.process   Installed
spo-recording-hello-openshift2-j2l2g   spo-recording-hello-openshift2-j2l2g_.process   Installed
spo-recording-hello-openshift2-t78hh   spo-recording-hello-openshift2-t78hh_.process   Installed

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
