### PR TITLE
CMP-3541: Release 0.9 update, add ServiceAccount for Prometheus in openshift-monitoring 

### DIFF
--- a/bundle-hack/prometheus-k8s.yaml
+++ b/bundle-hack/prometheus-k8s.yaml
@@ -1,0 +1,3 @@
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -489,6 +489,10 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 		return fmt.Errorf("start metrics grpc server: %w", err)
 	}
 
+	disableHTTP2 := func(c *tls.Config) {
+		c.NextProtos = []string{"http/1.1"}
+	}
+
 	ctrlOpts := ctrl.Options{
 		Cache:                  cache.Options{SyncPeriod: &sync},
 		HealthProbeBindAddress: fmt.Sprintf(":%d", config.HealthProbePort),
@@ -501,6 +505,7 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 			ExtraHandlers: map[string]http.Handler{
 				metrics.HandlerPath: met.Handler(),
 			},
+			TLSOpts: []func(*tls.Config){disableHTTP2},
 		},
 	}
 

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -838,7 +838,7 @@ var metricsService = &corev1.Service{
 	Spec: corev1.ServiceSpec{
 		Ports: []corev1.ServicePort{
 			{
-				Name:       "http",
+				Name:       "https",
 				Port:       servicePort,
 				TargetPort: intstr.FromInt32(ContainerPort),
 			},


### PR DESCRIPTION

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
[CMP-3541
](https://issues.redhat.com/browse/CMP-3541)
#### Does this PR have test?
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
```release-note

```
