### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for security-profiles-operator-release-0-9

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -31,7 +31,8 @@ LABEL \
         com.redhat.delivery.appregistry="false" \
         maintainer="Red Hat ISC <isc-team@redhat.com>" \
         License="APL 2.0" \
-        name="openshift-security-profiles-operator" \
+        name="compliance/openshift-security-profiles-rhel8-operator" \
+        cpe="cpe:/a:redhat:openshift_security_profiles_operator:1::el9" \
         com.redhat.component="openshift-security-profiles-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Security Profiles Operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
