### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for security-profiles-operator-bundle-release-0-9

### DIFF
--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -14,7 +14,7 @@ RUN ./update_bundle_rbac.sh
 FROM scratch
 ARG SPO_VERSION
 
-LABEL name=security-profiles-operator-bundle
+LABEL name="compliance/openshift-security-profiles-operator-bundle"
 LABEL version=${SPO_VERSION}
 LABEL summary='OpenShift Security Profiles Operator'
 LABEL maintainer='Infrastructure Security and Compliance Team <isc-team@redhat.com>'
@@ -26,6 +26,7 @@ LABEL vendor="Red Hat, Inc."
 LABEL distribution-scope="public"
 LABEL description='Security Profiles Operator'
 LABEL com.redhat.component=security-profiles-operator-bundle-container
+LABEL cpe="cpe:/a:redhat:openshift_security_profiles_operator:1::el9"
 LABEL com.redhat.delivery.appregistry=false
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.openshift.versions="v4.12"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
