### PR TITLE
CMP-3943, CMP-3941: Use ubi9-minimal and microdnf

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -18,12 +18,11 @@ ARG STATIC_LINK=no
 
 RUN make
 
-FROM registry.redhat.io/rhel9-4-els/rhel-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
-RUN INSTALL_PKGS="tar libseccomp" && \
-    if [ ! -e /usr/bin/dnf ]; then ln -s /usr/bin/microdnf /usr/bin/dnf; fi && \
-        dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-        dnf clean all && rm -rf /var/cache/*
+RUN microdnf install -y --setopt=tsflags=nodocs tar libseccomp
+RUN microdnf clean all && rm -rf /var/cache/*
+
 LABEL \
         io.k8s.display-name="Security Profiles Operator" \
         io.k8s.description="The Security Profiles Operator makes it easier for cluster admins to manage their seccomp, or SELinux profiles and apply them to Kubernetes' workloads." \


### PR DESCRIPTION
We can use ubi9 minimal since it covers all our cases and is FIPS validated. Also simplify the dnf and microdnf symlinking, which we don't need to have a conditional for if we're always using a minimal image. Using a minimal image is good since it reduces the overall surface area of the container image.