### PR TITLE
Build bundle for each PR

### DIFF
--- a/.tekton/security-profiles-operator-bundle-dev-pull-request.yaml
+++ b/.tekton/security-profiles-operator-bundle-dev-pull-request.yaml
@@ -132,6 +132,25 @@ spec:
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
     tasks:
+    - name: wait-for-operator-image
+      params:
+      - name: OPERATOR_IMAGE
+        value: quay.io/redhat-user-workloads/ocp-isc-tenant/security-profiles-operator-dev:on-pr-$(params.revision)
+      - name: ARCHITECTURES
+        value: "linux/amd64,linux/ppc64le"
+      - name: MAX_WAIT_TIME
+        value: "30m"
+      - name: CHECK_INTERVAL
+        value: "30s"
+      taskRef:
+        resolver: git
+        params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.revision)
+        - name: pathInRepo
+          value: ".tekton/tasks/wait-for-operator-image-task.yaml"
     - name: init
       params:
       - name: image-url
@@ -140,6 +159,8 @@ spec:
         value: $(params.rebuild)
       - name: skip-checks
         value: $(params.skip-checks)
+      runAfter:
+      - wait-for-operator-image
       taskRef:
         params:
         - name: name
@@ -225,6 +246,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - OPERATOR_IMAGE=$(tasks.wait-for-operator-image.results.OPERATOR_IMAGE_WITH_DIGEST)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED
@@ -235,6 +257,7 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
       - prefetch-dependencies
+      - wait-for-operator-image
       taskRef:
         params:
         - name: name

--- a/.tekton/tasks/wait-for-operator-image-task.yaml
+++ b/.tekton/tasks/wait-for-operator-image-task.yaml
@@ -1,0 +1,128 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: wait-for-operator-image
+spec:
+  description: |
+    Waits for an operator image to be available in the registry with all required architectures.
+    Returns the full image reference with digest (registry/repo/image@sha256:digest).
+    Note: This task only waits for the operator image, not selinuxd images (which are in a different repo).
+  params:
+  - name: OPERATOR_IMAGE
+    description: The operator image to wait for (with tag, e.g., quay.io/.../image:tag)
+    type: string
+  - name: ARCHITECTURES
+    description: Comma-separated list of architectures to wait for (e.g., "linux/amd64,linux/ppc64le,linux/s390x")
+    type: string
+    default: "linux/amd64,linux/ppc64le,linux/s390x"
+  - name: MAX_WAIT_TIME
+    description: Maximum time to wait (e.g., 30m, 1h)
+    type: string
+    default: "30m"
+  - name: CHECK_INTERVAL
+    description: Interval between checks (e.g., 30s, 1m)
+    type: string
+    default: "30s"
+  results:
+  - name: OPERATOR_IMAGE_WITH_DIGEST
+    description: Full operator image reference with digest (registry/repo/image@sha256:digest)
+  steps:
+  - name: wait
+    image: quay.io/openshift/origin-cli:latest
+    script: |
+      #!/bin/bash
+      set -e
+      
+      OPERATOR_IMAGE=$(params.OPERATOR_IMAGE)
+      ARCHITECTURES_PARAM=$(params.ARCHITECTURES)
+      MAX_WAIT_TIME=$(params.MAX_WAIT_TIME)
+      CHECK_INTERVAL=$(params.CHECK_INTERVAL)
+      
+      echo "Waiting for operator image to be available: ${OPERATOR_IMAGE}"
+      echo "Required architectures: ${ARCHITECTURES_PARAM}"
+      echo "Max wait time: ${MAX_WAIT_TIME}, Check interval: ${CHECK_INTERVAL}"
+      
+      # Convert comma-separated architectures to array
+      IFS=',' read -ra ARCHITECTURES <<< "$ARCHITECTURES_PARAM"
+      
+      # Convert MAX_WAIT_TIME to seconds
+      MAX_SECONDS=$(echo "$MAX_WAIT_TIME" | awk '{
+        if ($0 ~ /[0-9]+s/) { print int($0) }
+        else if ($0 ~ /[0-9]+m/) { print int($0) * 60 }
+        else if ($0 ~ /[0-9]+h/) { print int($0) * 3600 }
+        else { print int($0) }
+      }')
+      
+      # Convert CHECK_INTERVAL to seconds
+      INTERVAL_SECONDS=$(echo "$CHECK_INTERVAL" | awk '{
+        if ($0 ~ /[0-9]+s/) { print int($0) }
+        else if ($0 ~ /[0-9]+m/) { print int($0) * 60 }
+        else if ($0 ~ /[0-9]+h/) { print int($0) * 3600 }
+        else { print int($0) }
+      }')
+      
+      START_TIME=$(date +%s)
+      ELAPSED=0
+      
+      while [ $ELAPSED -lt $MAX_SECONDS ]; do
+        # Check if all required architectures are available
+        ALL_ARCH_AVAILABLE=true
+        MISSING_ARCHS=()
+        
+        for ARCH in "${ARCHITECTURES[@]}"; do
+          if ! oc image info "$OPERATOR_IMAGE" --filter-by-os="$ARCH" &>/dev/null; then
+            ALL_ARCH_AVAILABLE=false
+            MISSING_ARCHS+=("$ARCH")
+          fi
+        done
+        
+        if [ "$ALL_ARCH_AVAILABLE" = true ]; then
+          echo "✓ Operator image is now available with all architectures: ${OPERATOR_IMAGE}"
+          echo "Available architectures:"
+          for ARCH in "${ARCHITECTURES[@]}"; do
+            echo "  - ${ARCH}"
+          done
+          
+          # Get the manifest list digest (this is what we need for the bundle)
+          # The manifest list digest is shown when we query without --filter-by-os
+          MANIFEST_DIGEST=$(oc image info "$OPERATOR_IMAGE" 2>&1 | grep -i "manifest list:" | awk '{print $3}' || echo "")
+          if [ -z "$MANIFEST_DIGEST" ]; then
+            # Try alternative method - get digest from image info
+            MANIFEST_DIGEST=$(oc image info "$OPERATOR_IMAGE" --filter-by-os=linux/amd64 2>&1 | grep -i "manifest list:" | awk '{print $3}' || echo "")
+          fi
+          
+          if [ -z "$MANIFEST_DIGEST" ] || [[ ! "$MANIFEST_DIGEST" =~ ^sha256: ]]; then
+            echo "Error: Could not get manifest list digest from image: ${OPERATOR_IMAGE}"
+            exit 1
+          fi
+          
+          # Extract the base image name (remove tag and any existing digest)
+          # OPERATOR_IMAGE format: registry/repo/image:tag
+          # We want: registry/repo/image@sha256:digest
+          BASE_IMAGE="${OPERATOR_IMAGE%%:*}"  # Remove everything after first :
+          if [ "$BASE_IMAGE" = "$OPERATOR_IMAGE" ]; then
+            # No tag found, try removing @digest if present
+            BASE_IMAGE="${OPERATOR_IMAGE%%@*}"
+          fi
+          
+          OPERATOR_IMAGE_WITH_DIGEST="${BASE_IMAGE}@${MANIFEST_DIGEST}"
+          echo "Manifest list digest: ${MANIFEST_DIGEST}"
+          echo "Operator image with digest: ${OPERATOR_IMAGE_WITH_DIGEST}"
+          echo "${OPERATOR_IMAGE_WITH_DIGEST}" > $(results.OPERATOR_IMAGE_WITH_DIGEST.path)
+          
+          exit 0
+        else
+          echo "Waiting for image architectures... (elapsed: ${ELAPSED}s / ${MAX_SECONDS}s)"
+          echo "Missing architectures: ${MISSING_ARCHS[*]}"
+        fi
+        sleep $INTERVAL_SECONDS
+        
+        CURRENT_TIME=$(date +%s)
+        ELAPSED=$((CURRENT_TIME - START_TIME))
+      done
+      
+      echo "✗ Timeout: Operator image not available after ${MAX_WAIT_TIME}"
+      echo "Image: ${OPERATOR_IMAGE}"
+      echo "This may indicate the operator pipeline failed or is still running."
+      exit 1
+

--- a/bundle-hack/update_csv.go
+++ b/bundle-hack/update_csv.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -14,12 +15,16 @@ import (
 
 func main() {
 	if len(os.Args) < 3 {
-		fmt.Printf("Usage: %s <manifest_directory> <version>\n", os.Args[0])
+		fmt.Printf("Usage: %s <manifest_directory> <version> [operator-image]\n", os.Args[0])
 		os.Exit(1)
 	}
 
 	manifestDirectory := os.Args[1]
 	version := os.Args[2]
+	operatorImage := ""
+	if len(os.Args) > 3 {
+		operatorImage = os.Args[3]
+	}
 
 	buildManifestFilePath, err := getManifestFilePathFromDirectory(manifestDirectory)
 	if err != nil {
@@ -61,7 +66,7 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	if err := replaceImages(manifest); err != nil {
+	if err := replaceImages(manifest, operatorImage); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
@@ -182,7 +187,8 @@ func splitPullSpec(konfluxPullSpec string) (string, error) {
 // re-anchoring it to the Red Hat registry.
 //
 // RBAC proxy is a special case: it uses a static "latest" tag.
-func replaceImages(m map[string]interface{}) error {
+// Note: selinuxd images are kept hardcoded since they live in a different repo.
+func replaceImages(m map[string]interface{}, operatorImage string) error {
 	defer recoverFromReplaceImages()
 
 	// 1) Define your raw Konflux pull specs (with sha) and the
@@ -193,10 +199,18 @@ func replaceImages(m map[string]interface{}) error {
 		RedHatBase string // registry.redhat.io/...
 		FinalPS    string // will be set after extracting sha
 	}
+
+	// Use the operator image passed from the pipeline if provided
+	operatorKonfluxPS := operatorImage
+	if operatorKonfluxPS == "" {
+		// Fallback to hardcoded value if not provided (for backward compatibility)
+		operatorKonfluxPS = "quay.io/redhat-user-workloads/ocp-isc-tenant/security-profiles-operator-dev@sha256:15f7abcf8859b679535d11a0720cd4c3923e9194c12f600d05e1a7e81803e113"
+	}
+
 	defs := []imgDef{
 		{
 			EnvName:    "RELATED_IMAGE_OPERATOR",
-			KonfluxPS:  "quay.io/redhat-user-workloads/ocp-isc-tenant/security-profiles-operator-dev@sha256:15f7abcf8859b679535d11a0720cd4c3923e9194c12f600d05e1a7e81803e113",
+			KonfluxPS:  operatorKonfluxPS,
 			RedHatBase: "registry.redhat.io/compliance/openshift-security-profiles-rhel8-operator",
 		},
 		{
@@ -230,7 +244,7 @@ func replaceImages(m map[string]interface{}) error {
 		if defs[i].KonfluxPS != "" {
 			sha, err := splitPullSpec(defs[i].KonfluxPS)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to extract SHA from %s: %w", defs[i].KonfluxPS, err)
 			}
 			defs[i].FinalPS = defs[i].RedHatBase + sha
 		}
@@ -271,7 +285,8 @@ func replaceImages(m map[string]interface{}) error {
 	}
 
 	// 4) Update the container's image to the operator's FinalPS
-	ctr["image"] = defs[0].FinalPS
+	// Trim any whitespace/newlines to prevent YAML literal block formatting
+	ctr["image"] = strings.TrimSpace(defs[0].FinalPS)
 
 	// 5) Update each RELATED_IMAGE_* env var
 	envSlice, ok := ctr["env"].([]interface{})
@@ -286,7 +301,8 @@ func replaceImages(m map[string]interface{}) error {
 		name, _ := envVar["name"].(string)
 		for _, def := range defs {
 			if name == def.EnvName {
-				envVar["value"] = def.FinalPS
+				// Trim any whitespace/newlines to prevent YAML literal block formatting
+				envVar["value"] = strings.TrimSpace(def.FinalPS)
 				break
 			}
 		}
@@ -449,10 +465,17 @@ func writeManifest(m map[string]interface{}, manifestDirectory, version string) 
 	}
 	fmt.Printf("Successfully moved %s to %s.\n", oldCSVFilename, newCSVFilename)
 
-	out, err := yaml.Marshal(m)
-	if err != nil {
+	// Use encoder with options to prevent literal block formatting for strings
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	defer encoder.Close()
+
+	if err := encoder.Encode(m); err != nil {
 		return fmt.Errorf("failed to marshal YAML: %v", err)
 	}
+
+	out := buf.Bytes()
 
 	if err := os.WriteFile(newCSVFilename, out, 0644); err != nil {
 		return fmt.Errorf("failed to write updated manifest %s: %v", newCSVFilename, err)

--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -3,9 +3,10 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.24 as builder-r
 # Use a new stage to enable caching of the package installations for local development
 FROM builder-runner as builder
 ARG SPO_VERSION="0.9.0"
+ARG OPERATOR_IMAGE=""
 COPY . .
 WORKDIR bundle-hack
-RUN go run ./update_csv.go ../bundle/manifests ${SPO_VERSION}
+RUN go run ./update_csv.go ../bundle/manifests ${SPO_VERSION} "${OPERATOR_IMAGE}"
 RUN ./update_bundle_annotations.sh
 RUN ./update_bundle_namespace.sh
 RUN ./update_bundle_rbac.sh


### PR DESCRIPTION
Based on  https://github.com/openshift/security-profiles-operator/pull/107

Add wait-for-operator-image task to bundle pipeline

Wait for operator image to be available before building bundle and use
the actual image digest in the CSV. Selinuxd images remain hardcoded.