### PR TITLE
CMP-3955: Use different branch prefix for mintmaker updates 

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,53 @@
+{
+  "branchPrefix": "kflux/mintmaker/",
+  "schedule": [
+    "at any time"
+  ],
+  "tekton": {
+    "managerFilePatterns": [
+      "/\\.yaml$/",
+      "/\\.yml$/"
+    ],
+    "includePaths": [
+      ".tekton/**"
+    ],
+    "packageRules": [
+      {
+        "matchPackageNames": [
+          "/^quay.io/redhat-appstudio-tekton-catalog//",
+          "/^quay.io/konflux-ci/tekton-catalog//"
+        ],
+        "enabled": true,
+        "groupName": "Konflux references",
+        "branchPrefix": "klux/references/",
+        "additionalBranchPrefix": "",
+        "group": {
+          "branchTopic": "{{{baseBranch}}}",
+          "commitMessageTopic": "{{{groupName}}}"
+        },
+        "commitMessageTopic": "Konflux references",
+        "prBodyColumns": [
+          "Package",
+          "Change",
+          "Notes"
+        ],
+        "prBodyDefinitions": {
+          "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '^quay.io/(redhat-appstudio-tekton-catalog|konflux-ci/tekton-catalog)/task-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}"
+        },
+        "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
+        "recreateWhen": "always",
+        "rebaseWhen": "behind-base-branch"
+      }
+    ],
+    "schedule": [
+      "at any time"
+    ],
+    "postUpgradeTasks": {
+      "commands": [
+        "pipeline-migration-tool migrate -f \"$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\""
+      ],
+      "executionMode": "branch",
+      "dataFileTemplate": "[{{#each upgrades}}{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"currentDigest\": \"{{{currentDigest}}}\", \"newValue\": \"{{{newValue}}}\", \"newDigest\": \"{{{newDigest}}}\", \"packageFile\": \"{{{packageFile}}}\", \"parentDir\": \"{{{parentDir}}}\", \"depTypes\": [{{#each depTypes}}\"{{{this}}}\"{{#unless @last}},{{/unless}}{{/each}}]}{{#unless @last}},{{/unless}}{{/each}}]"
+    }
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,24 @@
 {
+  "extends": [
+    "config:recommended"
+  ],
   "branchPrefix": "kflux/mintmaker/",
   "schedule": [
     "at any time"
   ],
+  "gomod": {
+    "packageRules": [
+      {
+        "matchManagers": [
+          "gomod"
+        ],
+        "matchBaseBranches": [
+          "/^release-.*/"
+        ],
+        "enabled": false
+      }
+    ]
+  },
   "tekton": {
     "managerFilePatterns": [
       "/\\.yaml$/",


### PR DESCRIPTION
As we are using Konflux branch to pull changes from upstream, we need to use a different branch for mintmaker.
- Change Renovate `branchPrefix`
- Disable gomod dependency updates on release branches
- Adjust for a more frequent schedule