### PR TITLE
CMP-3537: Fix keycreate error for recording on OpenShift 4.20+

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -332,6 +332,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/base/profiles/selinuxrecording.cil
+++ b/deploy/base/profiles/selinuxrecording.cil
@@ -1,4 +1,7 @@
 (block selinuxrecording
   (blockinherit container)
   (typepermissive process)
+  (typeattributeset file_type (process))
+  (allow container_runtime_t process (file (relabelfrom relabelto)))
+  (allow container_runtime_t process (dir (relabelfrom relabelto)))
 )

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -1018,6 +1018,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3355,6 +3355,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3342,6 +3342,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3373,6 +3373,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3355,6 +3355,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3326,6 +3326,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1


### PR DESCRIPTION
 Add selinuxrecording.process to file_type attribute to fix container
  creation failure with "write to /proc/self/attr/keycreate: Invalid
  argument" on OpenShift 4.20 where CRI-O/crun 1.23+ strictly validates
  keycreate contexts.