### PR TITLE
CMP-3537: Fix profile recording

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -332,6 +332,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/base/profiles/selinuxrecording.cil
+++ b/deploy/base/profiles/selinuxrecording.cil
@@ -1,4 +1,7 @@
 (block selinuxrecording
   (blockinherit container)
   (typepermissive process)
+  (typeattributeset file_type (process))
+  (allow container_runtime_t process (file (relabelfrom relabelto)))
+  (allow container_runtime_t process (dir (relabelfrom relabelto)))
 )

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -1018,6 +1018,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3355,6 +3355,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3342,6 +3342,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3373,6 +3373,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3355,6 +3355,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3326,6 +3326,9 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
+      (typeattributeset file_type (process))
+      (allow container_runtime_t process (file (relabelfrom relabelto)))
+      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -242,6 +242,7 @@ chmod 750 /etc/selinux.d
 semodule -i /usr/share/selinuxd/templates/*.cil
 semodule -i /opt/spo-profiles/selinuxd.cil
 semodule -i /opt/spo-profiles/selinuxrecording.cil
+semodule -R
 `,
 						},
 						VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Reload the SELinux policy is needed, otherwise you will still get the keycreate error.
This PR a test PR. It is based on https://github.com/openshift/security-profiles-operator/pull/123.

#### Which issue(s) this PR fixes:



#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
