### PR TITLE
CMP-4007: seccomp: add statx syscall to fix runc 1.2 compatibility

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -105,6 +105,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "write"
@@ -259,6 +260,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "unshare",

--- a/deploy/base/profiles/bpf-recorder.json
+++ b/deploy/base/profiles/bpf-recorder.json
@@ -102,6 +102,7 @@
         "socket",
         "stat",
         "statfs",
+        "statx",
         "tgkill",
         "uname",
         "write"

--- a/deploy/base/profiles/security-profiles-operator.json
+++ b/deploy/base/profiles/security-profiles-operator.json
@@ -1,33 +1,33 @@
 {
   "defaultAction": "SCMP_ACT_ERRNO",
-    "archMap": [
-        {
-            "architecture": "SCMP_ARCH_X86_64",
-            "subArchitectures": [
-                "SCMP_ARCH_X86",
-                "SCMP_ARCH_X32"
-            ]
-        },
-        {
-            "architecture": "SCMP_ARCH_AARCH64",
-            "subArchitectures": [
-                "SCMP_ARCH_ARM"
-            ]
-        },
-        {
-        "architecture": "SCMP_ARCH_PPC64LE",
-            "subArchitectures": [
-                "SCMP_ARCH_PPC64",
-                "SCMP_ARCH_PPC"
-            ]
-        },
-        {
-            "architecture": "SCMP_ARCH_S390X",
-            "subArchitectures": [
-                "SCMP_ARCH_S390"
-            ]
-        }
-    ],
+  "archMap": [
+    {
+      "architecture": "SCMP_ARCH_X86_64",
+      "subArchitectures": [
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_AARCH64",
+      "subArchitectures": [
+        "SCMP_ARCH_ARM"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_PPC64LE",
+      "subArchitectures": [
+        "SCMP_ARCH_PPC64",
+        "SCMP_ARCH_PPC"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_S390X",
+      "subArchitectures": [
+        "SCMP_ARCH_S390"
+      ]
+    }
+  ],
   "syscalls": [
     {
       "names": [
@@ -95,6 +95,7 @@
         "socket",
         "stat",
         "statfs",
+        "statx",
         "tgkill",
         "uname",
         "unshare",

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -791,6 +791,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "write"
@@ -945,6 +946,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "unshare",

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3128,6 +3128,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "write"
@@ -3282,6 +3283,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "unshare",

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3115,6 +3115,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "write"
@@ -3269,6 +3270,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "unshare",

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3146,6 +3146,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "write"
@@ -3300,6 +3301,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "unshare",

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3128,6 +3128,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "write"
@@ -3282,6 +3283,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "unshare",

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3099,6 +3099,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "write"
@@ -3253,6 +3254,7 @@ data:
             "socket",
             "stat",
             "statfs",
+            "statx",
             "tgkill",
             "uname",
             "unshare",


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

runc 1.2 introduced new /proc mount security checks that require the statx syscall. Without it, containers using SPO's seccomp profiles crash with:

  reopen exec fifo: get safe /proc/thread-self/fd handle: check
  "thread-self" component is not overmounted: get root mount id:
  statx(STATX_MNT_ID_...) fsmount:fscontext:proc/: could not get
  mount id: operation not permitted

Add statx to both security-profiles-operator.json and bpf-recorder.json
seccomp profiles to ensure compatibility with runc 1.2.

This affects OpenShift 4.17 and below, which use runc. OpenShift 4.18+
uses crun instead and is not affected."
#### Which issue(s) this PR fixes:
[CMP-4007](https://issues.redhat.com/browse/CMP-4007)

#### Does this PR have test?
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE