### PR TITLE
NO-JIRA: missing labels keep the pacakagemanifest from being displayed in the catalog

### DIFF
--- a/bundle-hack/update_csv.go
+++ b/bundle-hack/update_csv.go
@@ -137,7 +137,8 @@ func addRequiredAnnotations(m map[string]interface{}) error {
 // addRequiredLabels adds required labels under metadata.labels
 func addRequiredLabels(m map[string]interface{}) error {
 	requiredLabels := map[string]string{
-		"operatorframework.io/arch.amd64": "supported",
+		"operatorframework.io/arch.amd64":   "supported",
+		"operatorframework.io/arch.ppc64le": "supported",
 	}
 
 	metadata, ok := m["metadata"].(map[string]interface{})


### PR DESCRIPTION
NO-JIRA: missing labels keep the pacakagemanifest from being displayed in the catalog