### PR TITLE
CMP-3537: Revert selinux keycreate fix and policy reload

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -338,9 +338,6 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
-      (typeattributeset file_type (process))
-      (allow container_runtime_t process (file (relabelfrom relabelto)))
-      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/base/profiles/selinuxrecording.cil
+++ b/deploy/base/profiles/selinuxrecording.cil
@@ -1,7 +1,4 @@
 (block selinuxrecording
   (blockinherit container)
   (typepermissive process)
-  (typeattributeset file_type (process))
-  (allow container_runtime_t process (file (relabelfrom relabelto)))
-  (allow container_runtime_t process (dir (relabelfrom relabelto)))
 )

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -1024,9 +1024,6 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
-      (typeattributeset file_type (process))
-      (allow container_runtime_t process (file (relabelfrom relabelto)))
-      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3357,9 +3357,6 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
-      (typeattributeset file_type (process))
-      (allow container_runtime_t process (file (relabelfrom relabelto)))
-      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3344,9 +3344,6 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
-      (typeattributeset file_type (process))
-      (allow container_runtime_t process (file (relabelfrom relabelto)))
-      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3375,9 +3375,6 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
-      (typeattributeset file_type (process))
-      (allow container_runtime_t process (file (relabelfrom relabelto)))
-      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3357,9 +3357,6 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
-      (typeattributeset file_type (process))
-      (allow container_runtime_t process (file (relabelfrom relabelto)))
-      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3328,9 +3328,6 @@ data:
     (block selinuxrecording
       (blockinherit container)
       (typepermissive process)
-      (typeattributeset file_type (process))
-      (allow container_runtime_t process (file (relabelfrom relabelto)))
-      (allow container_runtime_t process (dir (relabelfrom relabelto)))
     )
   spo-apparmor.yaml: |
     apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -242,7 +242,6 @@ chmod 750 /etc/selinux.d
 semodule -i /usr/share/selinuxd/templates/*.cil
 semodule -i /opt/spo-profiles/selinuxd.cil
 semodule -i /opt/spo-profiles/selinuxrecording.cil
-semodule -R
 `,
 						},
 						VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Reverts:
- a0a23f024 selinux: fix keycreate error for recording on OpenShift 4.20+
- 3c39cf3b4 Reload the SELinux policy

The original fix was not needed, as manually do semodule -R using oc debug node command will fix the issue.

#### Which issue(s) this PR fixes:

None


#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE
