### PR TITLE
 CMP-3537: Add privileged Job to reload kernel policy after SELinux profile install

### DIFF
--- a/deploy/base/role.yaml
+++ b/deploy/base/role.yaml
@@ -247,6 +247,16 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
   - apparmorprofiles

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -306,6 +306,16 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
   - apparmorprofiles

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2709,6 +2709,16 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
   - apparmorprofiles

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2835,6 +2835,16 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
   - apparmorprofiles

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2714,6 +2714,16 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
   - apparmorprofiles

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2709,6 +2709,16 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
   - apparmorprofiles

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2819,6 +2819,16 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
   - apparmorprofiles

--- a/internal/pkg/daemon/selinuxprofile/common_controller.go
+++ b/internal/pkg/daemon/selinuxprofile/common_controller.go
@@ -78,6 +78,12 @@ const (
 	reasonCannotGetPolicyStatus    string = "CannotGetPolicyStatus"
 	reasonCannotUpdatePolicyStatus string = "CannotUpdatePolicyStatus"
 	reasonInstalledPolicy          string = "SavedSelinuxPolicy"
+	reasonCannotReloadPolicy       string = "CannotReloadSelinuxPolicy"
+)
+
+const (
+	reloadInstallGenerationAnnotation = "spo.x-k8s.io/selinux-policy-reload-generation"
+	reloadRemoveGenerationAnnotation  = "spo.x-k8s.io/selinux-policy-reload-remove-generation"
 )
 
 // blank assignment to verify that ReconcileSelinux implements `reconcile.Reconciler`.
@@ -156,6 +162,8 @@ func (r *ReconcileSelinux) Healthz(*http.Request) error {
 // +kubebuilder:rbac:groups=security-profiles-operator.x-k8s.io,resources=rawselinuxprofiles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=security-profiles-operator.x-k8s.io,resources=rawselinuxprofiles/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=security-profiles-operator.x-k8s.io,resources=rawselinuxprofiles/finalizers,verbs=delete;get;update;patch
+
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;delete;get;list;watch
 
 // Reconcile reads that state of the cluster for a SelinuxProfile object and makes changes based on the state read
 // and what is in the `SelinuxProfile.Spec`.
@@ -318,6 +326,29 @@ func (r *ReconcileSelinux) reconcilePolicy(
 
 		r.metrics.IncSelinuxProfileUpdate()
 		r.record.Event(sp, util.EventTypeNormal, reasonInstalledPolicy, evstr)
+
+		reloadGeneration := strconv.FormatInt(sp.GetGeneration(), 10)
+		lastReloadGeneration, err := nodeStatus.GetAnnotation(ctx, reloadInstallGenerationAnnotation)
+		if err != nil {
+			l.Error(err, "Failed to read reload generation annotation")
+		}
+
+		if lastReloadGeneration == reloadGeneration {
+			l.Info("Reload already performed for policy generation, skipping",
+				"generation", reloadGeneration, "policyName", sp.GetPolicyName())
+		} else {
+			// On RHEL 9/OpenShift 4.20+, semodule -i no longer automatically reloads
+			// the kernel's in-memory policy. Create a short-lived privileged Job to
+			// run semodule -R and reload the policy.
+			if err := r.createPolicyReloadJob(ctx, sp.GetPolicyName(), "install", l); err != nil {
+				l.Error(err, "Failed to create policy reload job, policy may not be active until manual reload")
+				r.record.Event(sp, util.EventTypeWarning, reasonCannotReloadPolicy,
+					fmt.Sprintf("Failed to create policy reload job on %s: %s", os.Getenv(config.NodeNameEnvKey), err.Error()))
+				// Don't fail the reconcile - the policy is installed, just not reloaded yet
+			} else if err := nodeStatus.SetAnnotation(ctx, reloadInstallGenerationAnnotation, reloadGeneration); err != nil {
+				l.Error(err, "Failed to set reload generation annotation")
+			}
+		}
 	case failedStatus:
 		polState = statusv1alpha1.ProfileStateError
 		evstr := fmt.Sprintf("Failed to save profile to disk on %s: %s", os.Getenv(config.NodeNameEnvKey), polStatus.Msg)
@@ -385,6 +416,23 @@ func (r *ReconcileSelinux) reconcileDeletePolicy(
 	polStatus, err := getPolicyStatus(ctx, sp, r.httpc)
 
 	if errors.Is(err, errPolicyNotFound) {
+		// Policy was successfully removed, trigger a reload to update kernel policy
+		reloadGeneration := strconv.FormatInt(sp.GetGeneration(), 10)
+		lastReloadGeneration, err := nodeStatus.GetAnnotation(ctx, reloadRemoveGenerationAnnotation)
+		if err != nil {
+			l.Error(err, "Failed to read reload generation annotation after removal")
+		}
+
+		if lastReloadGeneration == reloadGeneration {
+			l.Info("Reload already performed for policy removal, skipping",
+				"generation", reloadGeneration, "policyName", sp.GetPolicyName())
+		} else if err := r.createPolicyReloadJob(ctx, sp.GetPolicyName(), "remove", l); err != nil {
+			l.Error(err, "Failed to create policy reload job after removal")
+			r.record.Event(sp, util.EventTypeWarning, reasonCannotReloadPolicy,
+				fmt.Sprintf("Failed to create policy reload job after removal on %s: %s", os.Getenv(config.NodeNameEnvKey), err.Error()))
+		} else if err := nodeStatus.SetAnnotation(ctx, reloadRemoveGenerationAnnotation, reloadGeneration); err != nil {
+			l.Error(err, "Failed to set reload generation annotation after removal")
+		}
 		return reconcile.Result{}, nil
 	}
 

--- a/internal/pkg/daemon/selinuxprofile/common_controller.go
+++ b/internal/pkg/daemon/selinuxprofile/common_controller.go
@@ -227,7 +227,7 @@ func (r *ReconcileSelinux) Reconcile(ctx context.Context, request reconcile.Requ
 		r.record.Event(instance, util.EventTypeWarning, reasonCannotRemovePolicy, err.Error())
 
 		return res, err
-	} else if res.RequeueAfter > 0 {
+	} else if res.RequeueAfter > 0 || res.Requeue {
 		reqLogger.Info("Re-queueing delete request to make sure the policy is gone")
 
 		return res, err
@@ -288,12 +288,28 @@ func (r *ReconcileSelinux) reconcilePolicy(
 		return reconcile.Result{}, nil
 	}
 
-	err = r.reconcilePolicyFile(sp, oh, l)
+	policyUpdated, err := r.reconcilePolicyFile(sp, oh, l)
 	if err != nil {
 		r.metrics.IncSelinuxProfileError(reasonCannotWritePolicyFile)
 		r.record.Event(sp, util.EventTypeWarning, reasonCannotWritePolicyFile, err.Error())
 
 		return reconcile.Result{}, fmt.Errorf("creating policy file: %w", err)
+	}
+
+	// If the policy file was just updated, requeue to give selinuxd time to detect
+	// the change and reinstall the policy before we check status and trigger reload.
+	// Without this, we might trigger the reload job before selinuxd has processed the update.
+	if policyUpdated {
+		l.Info("Policy file updated, requeuing to allow selinuxd to process the change")
+
+		if err := nodeStatus.SetNodeStatus(ctx, statusv1alpha1.ProfileStateInProgress); err != nil {
+			r.metrics.IncSelinuxProfileError(reasonCannotUpdatePolicyStatus)
+			r.record.Event(sp, util.EventTypeWarning, reasonCannotUpdatePolicyStatus, err.Error())
+
+			return reconcile.Result{}, fmt.Errorf("setting node status to in progress: %w", err)
+		}
+
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	l.Info("Checking if policy deployed", "policyName", sp.GetName())
@@ -340,14 +356,19 @@ func (r *ReconcileSelinux) reconcilePolicy(
 			// On RHEL 9/OpenShift 4.20+, semodule -i no longer automatically reloads
 			// the kernel's in-memory policy. Create a short-lived privileged Job to
 			// run semodule -R and reload the policy.
-			if err := r.createPolicyReloadJob(ctx, sp.GetPolicyName(), "install", l); err != nil {
+			jobCreated, err := r.createPolicyReloadJob(ctx, sp.GetPolicyName(), "install", l)
+			if err != nil {
 				l.Error(err, "Failed to create policy reload job, policy may not be active until manual reload")
 				r.record.Event(sp, util.EventTypeWarning, reasonCannotReloadPolicy,
 					fmt.Sprintf("Failed to create policy reload job on %s: %s", os.Getenv(config.NodeNameEnvKey), err.Error()))
 				// Don't fail the reconcile - the policy is installed, just not reloaded yet
-			} else if err := nodeStatus.SetAnnotation(ctx, reloadInstallGenerationAnnotation, reloadGeneration); err != nil {
-				l.Error(err, "Failed to set reload generation annotation")
+			} else if jobCreated {
+				// Only update the annotation if a job was actually created
+				if err := nodeStatus.SetAnnotation(ctx, reloadInstallGenerationAnnotation, reloadGeneration); err != nil {
+					l.Error(err, "Failed to set reload generation annotation")
+				}
 			}
+			// If jobCreated is false (skipped due to TTL), don't update annotation - will retry on next reconcile
 		}
 	case failedStatus:
 		polState = statusv1alpha1.ProfileStateError
@@ -369,25 +390,28 @@ func (r *ReconcileSelinux) reconcilePolicy(
 	return reconcile.Result{}, nil
 }
 
+// reconcilePolicyFile writes the policy file to the drop directory if the content differs.
+// Returns (policyUpdated, error) where policyUpdated is true if the file was actually written.
 func (r *ReconcileSelinux) reconcilePolicyFile(
 	sp selxv1alpha2.SelinuxProfileObject,
 	oh SelinuxObjectHandler,
 	l logr.Logger,
-) error {
+) (bool, error) {
 	policyPath := path.Join(bindata.SelinuxDropDirectory, sp.GetPolicyName()+".cil")
 
 	cil, parseErr := oh.GetCILPolicy()
 	if parseErr != nil {
-		return fmt.Errorf("generating CIL: %w", parseErr)
+		return false, fmt.Errorf("generating CIL: %w", parseErr)
 	}
 
 	policyContent := []byte(cil)
 
-	if err := writeFileIfDiffers(policyPath, policyContent, l); err != nil {
-		return fmt.Errorf("writing policy file: %w", err)
+	written, err := writeFileIfDiffers(policyPath, policyContent, l)
+	if err != nil {
+		return false, fmt.Errorf("writing policy file: %w", err)
 	}
 
-	return nil
+	return written, nil
 }
 
 func (r *ReconcileSelinux) reconcileDeletePolicy(
@@ -408,7 +432,7 @@ func (r *ReconcileSelinux) reconcileDeletePolicy(
 	}
 
 	res, err := r.reconcileDeletePolicyFile(sp, l)
-	if res.RequeueAfter > 0 || err != nil {
+	if res.RequeueAfter > 0 || res.Requeue || err != nil {
 		return res, err
 	}
 
@@ -426,12 +450,17 @@ func (r *ReconcileSelinux) reconcileDeletePolicy(
 		if lastReloadGeneration == reloadGeneration {
 			l.Info("Reload already performed for policy removal, skipping",
 				"generation", reloadGeneration, "policyName", sp.GetPolicyName())
-		} else if err := r.createPolicyReloadJob(ctx, sp.GetPolicyName(), "remove", l); err != nil {
-			l.Error(err, "Failed to create policy reload job after removal")
-			r.record.Event(sp, util.EventTypeWarning, reasonCannotReloadPolicy,
-				fmt.Sprintf("Failed to create policy reload job after removal on %s: %s", os.Getenv(config.NodeNameEnvKey), err.Error()))
-		} else if err := nodeStatus.SetAnnotation(ctx, reloadRemoveGenerationAnnotation, reloadGeneration); err != nil {
-			l.Error(err, "Failed to set reload generation annotation after removal")
+		} else {
+			jobCreated, err := r.createPolicyReloadJob(ctx, sp.GetPolicyName(), "remove", l)
+			if err != nil {
+				l.Error(err, "Failed to create policy reload job after removal")
+				r.record.Event(sp, util.EventTypeWarning, reasonCannotReloadPolicy,
+					fmt.Sprintf("Failed to create policy reload job after removal on %s: %s", os.Getenv(config.NodeNameEnvKey), err.Error()))
+			} else if jobCreated {
+				if err := nodeStatus.SetAnnotation(ctx, reloadRemoveGenerationAnnotation, reloadGeneration); err != nil {
+					l.Error(err, "Failed to set reload generation annotation after removal")
+				}
+			}
 		}
 		return reconcile.Result{}, nil
 	}
@@ -554,34 +583,37 @@ func selinuxdGetRequest(ctx context.Context, httpc *http.Client, url string) (*h
 
 // writeFileIfDiffers checks if the content of file at filePath are the same as the byte array
 // contents, if not, overwrites the file at filePath.
+// Returns (written, error) where written is true if the file was actually written (content differed or file didn't exist).
 //
 // Reopening the same file may seem wasteful and even look like a TOCTOU issue, but the policy
 // drop dir is private to this pod, but mostly just calling a single write is much easier codepath
 // than mucking around with seeks and truncates to account for all the corner cases.
-func writeFileIfDiffers(filePath string, contents []byte, l logr.Logger) error {
+func writeFileIfDiffers(filePath string, contents []byte, l logr.Logger) (bool, error) {
 	const filePermissions = 0o600
 
 	file, err := os.OpenFile(filePath, os.O_RDONLY, filePermissions)
 	if os.IsNotExist(err) {
 		file.Close()
 
-		return os.WriteFile(filePath, contents, filePermissions)
+		l.Info("Writing new policy file", "policyPath", filePath)
+
+		return true, os.WriteFile(filePath, contents, filePermissions)
 	} else if err != nil {
-		return fmt.Errorf("could not open for reading: %w"+filePath, err)
+		return false, fmt.Errorf("could not open for reading: %w"+filePath, err)
 	}
 
 	defer file.Close()
 
 	existing, err := io.ReadAll(file)
 	if err != nil {
-		return fmt.Errorf("reading file : %w"+filePath, err)
+		return false, fmt.Errorf("reading file : %w"+filePath, err)
 	}
 
 	if bytes.Equal(existing, contents) {
-		return nil
+		return false, nil
 	}
 
-	l.Info("Writing to policy file", "policyPath", filePath)
+	l.Info("Updating policy file", "policyPath", filePath)
 
-	return os.WriteFile(filePath, contents, filePermissions)
+	return true, os.WriteFile(filePath, contents, filePermissions)
 }

--- a/internal/pkg/daemon/selinuxprofile/reload_job.go
+++ b/internal/pkg/daemon/selinuxprofile/reload_job.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selinuxprofile
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/manager/spod/bindata"
+)
+
+const (
+	reloadJobNamePrefix = "selinux-policy-reload-"
+	reloadJobTTL        = int32(120) // 2 minutes TTL after completion
+)
+
+// createPolicyReloadJob creates a short-lived privileged Job to run semodule -R
+// on the current node. This is needed because on RHEL 9/OpenShift 4.20+,
+// semodule -i no longer automatically reloads the kernel's in-memory policy.
+func (r *ReconcileSelinux) createPolicyReloadJob(
+	ctx context.Context,
+	policyName string,
+	action string,
+	l logr.Logger,
+) error {
+	nodeName := os.Getenv(config.NodeNameEnvKey)
+	if nodeName == "" {
+		return fmt.Errorf("NODE_NAME environment variable not set")
+	}
+
+	namespace := config.GetOperatorNamespace()
+
+	// Get the selinuxd image from the current pod's selinuxd container.
+	// The operator sets the correct per-node image when creating the spod DaemonSet.
+	selinuxdImage, err := r.getSelinuxdImageFromPod(ctx, namespace)
+	if err != nil {
+		return fmt.Errorf("getting selinuxd image: %w", err)
+	}
+
+	// Check if a reload job for this node is already running or was recently created
+	existingJobs := &batchv1.JobList{}
+	if err := r.client.List(ctx, existingJobs,
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			"app":    "selinux-policy-reload",
+			"node":   nodeName,
+			"policy": policyName,
+			"action": action,
+		}); err != nil {
+		l.Error(err, "Failed to list existing reload jobs")
+	} else {
+		now := time.Now()
+		for i := range existingJobs.Items {
+			job := &existingJobs.Items[i]
+			// Skip if a job is currently running
+			if job.Status.Succeeded == 0 && job.Status.Failed == 0 {
+				l.Info("Reload job already running for this node, skipping", "existingJob", job.Name)
+				return nil
+			}
+			// Skip if a job was created recently (within TTL window) to avoid duplicate reloads
+			if job.CreationTimestamp.Add(time.Duration(reloadJobTTL) * time.Second).After(now) {
+				l.Info("Reload job was recently created for this node, skipping",
+					"existingJob", job.Name, "age", now.Sub(job.CreationTimestamp.Time))
+				return nil
+			}
+		}
+	}
+
+	// Use a unique job name based on timestamp to avoid conflicts
+	jobName := fmt.Sprintf("%s%s-%d", reloadJobNamePrefix, nodeName[:min(10, len(nodeName))], time.Now().Unix())
+
+	privileged := true
+	hostPathDirectory := corev1.HostPathDirectory
+	backoffLimit := int32(3)
+	ttlSeconds := reloadJobTTL
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":     "selinux-policy-reload",
+				"node":    nodeName,
+				"policy":  policyName,
+				"action":  action,
+				"created": fmt.Sprintf("%d", time.Now().Unix()),
+			},
+		},
+		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: &ttlSeconds,
+			BackoffLimit:            &backoffLimit,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":    "selinux-policy-reload",
+						"node":   nodeName,
+						"policy": policyName,
+					},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
+					NodeName:           nodeName,
+					ServiceAccountName: "spod",
+					Containers: []corev1.Container{
+						{
+							Name:    "semodule-reload",
+							Image:   selinuxdImage,
+							Command: []string{"/bin/bash", "-c"},
+							Args: []string{
+								`echo "Reloading SELinux policy..."
+semodule -R
+exit_code=$?
+if [ $exit_code -eq 0 ]; then
+    echo "SELinux policy reload successful"
+else
+    echo "SELinux policy reload failed with exit code $exit_code"
+fi
+exit $exit_code`,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "host-fsselinux",
+									MountPath: "/sys/fs/selinux",
+								},
+								{
+									Name:      "host-etcselinux",
+									MountPath: "/etc/selinux",
+								},
+								{
+									Name:      "host-varlibselinux",
+									MountPath: "/var/lib/selinux",
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &privileged,
+								SELinuxOptions: &corev1.SELinuxOptions{
+									Type: "spc_t",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "host-fsselinux",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/sys/fs/selinux",
+									Type: &hostPathDirectory,
+								},
+							},
+						},
+						{
+							Name: "host-etcselinux",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/etc/selinux",
+									Type: &hostPathDirectory,
+								},
+							},
+						},
+						{
+							Name: "host-varlibselinux",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/var/lib/selinux",
+									Type: &hostPathDirectory,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	l.Info("Creating SELinux policy reload job", "jobName", jobName, "nodeName", nodeName, "policyName", policyName)
+
+	if err := r.client.Create(ctx, job); err != nil {
+		if kerrors.IsAlreadyExists(err) {
+			l.Info("Reload job already exists, skipping", "jobName", jobName)
+			return nil
+		}
+		return fmt.Errorf("creating reload job: %w", err)
+	}
+
+	l.Info("Successfully created SELinux policy reload job", "jobName", jobName)
+	return nil
+}
+
+// getSelinuxdImageFromPod retrieves the selinuxd container image from the current pod.
+// This is needed because the selinuxd image is set per-node by the operator based on
+// the node's OS, so it's not available as an environment variable.
+func (r *ReconcileSelinux) getSelinuxdImageFromPod(ctx context.Context, namespace string) (string, error) {
+	podName := os.Getenv("POD_NAME")
+	if podName == "" {
+		return "", fmt.Errorf("POD_NAME environment variable not set")
+	}
+
+	pod := &corev1.Pod{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: podName, Namespace: namespace}, pod); err != nil {
+		return "", fmt.Errorf("getting pod %s: %w", podName, err)
+	}
+
+	// Find the selinuxd container and get its image
+	for _, container := range pod.Spec.Containers {
+		if container.Name == bindata.SelinuxContainerName {
+			return container.Image, nil
+		}
+	}
+
+	return "", fmt.Errorf("selinuxd container not found in pod %s", podName)
+}

--- a/internal/pkg/daemon/selinuxprofile/reload_job.go
+++ b/internal/pkg/daemon/selinuxprofile/reload_job.go
@@ -42,15 +42,16 @@ const (
 // createPolicyReloadJob creates a short-lived privileged Job to run semodule -R
 // on the current node. This is needed because on RHEL 9/OpenShift 4.20+,
 // semodule -i no longer automatically reloads the kernel's in-memory policy.
+// Returns (jobCreated, error) where jobCreated is true if a new job was actually created.
 func (r *ReconcileSelinux) createPolicyReloadJob(
 	ctx context.Context,
 	policyName string,
 	action string,
 	l logr.Logger,
-) error {
+) (bool, error) {
 	nodeName := os.Getenv(config.NodeNameEnvKey)
 	if nodeName == "" {
-		return fmt.Errorf("NODE_NAME environment variable not set")
+		return false, fmt.Errorf("NODE_NAME environment variable not set")
 	}
 
 	namespace := config.GetOperatorNamespace()
@@ -59,7 +60,7 @@ func (r *ReconcileSelinux) createPolicyReloadJob(
 	// The operator sets the correct per-node image when creating the spod DaemonSet.
 	selinuxdImage, err := r.getSelinuxdImageFromPod(ctx, namespace)
 	if err != nil {
-		return fmt.Errorf("getting selinuxd image: %w", err)
+		return false, fmt.Errorf("getting selinuxd image: %w", err)
 	}
 
 	// Check if a reload job for this node is already running or was recently created
@@ -80,13 +81,13 @@ func (r *ReconcileSelinux) createPolicyReloadJob(
 			// Skip if a job is currently running
 			if job.Status.Succeeded == 0 && job.Status.Failed == 0 {
 				l.Info("Reload job already running for this node, skipping", "existingJob", job.Name)
-				return nil
+				return false, nil
 			}
 			// Skip if a job was created recently (within TTL window) to avoid duplicate reloads
 			if job.CreationTimestamp.Add(time.Duration(reloadJobTTL) * time.Second).After(now) {
 				l.Info("Reload job was recently created for this node, skipping",
 					"existingJob", job.Name, "age", now.Sub(job.CreationTimestamp.Time))
-				return nil
+				return false, nil
 			}
 		}
 	}
@@ -203,13 +204,13 @@ exit $exit_code`,
 	if err := r.client.Create(ctx, job); err != nil {
 		if kerrors.IsAlreadyExists(err) {
 			l.Info("Reload job already exists, skipping", "jobName", jobName)
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("creating reload job: %w", err)
+		return false, fmt.Errorf("creating reload job: %w", err)
 	}
 
 	l.Info("Successfully created SELinux policy reload job", "jobName", jobName)
-	return nil
+	return true, nil
 }
 
 // getSelinuxdImageFromPod retrieves the selinuxd container image from the current pod.

--- a/internal/pkg/daemon/selinuxprofile/reload_job_test.go
+++ b/internal/pkg/daemon/selinuxprofile/reload_job_test.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selinuxprofile
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/manager/spod/bindata"
+)
+
+func TestCreatePolicyReloadJob(t *testing.T) {
+	t.Parallel()
+
+	// Set up required environment variables
+	testNodeName := "test-node-12345"
+	testNamespace := "security-profiles-operator"
+	testPodName := "spod-test-pod"
+	testImage := "registry.example.com/selinuxd:test"
+	testAction := "install"
+
+	schemeInstance := scheme.Scheme
+	if err := batchv1.AddToScheme(schemeInstance); err != nil {
+		t.Fatalf("couldn't add batch API to scheme: %v", err)
+	}
+
+	// Create test pod with selinuxd container
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: testNamespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "security-profiles-operator",
+					Image: "registry.example.com/spo:test",
+				},
+				{
+					Name:  bindata.SelinuxContainerName,
+					Image: testImage,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		nodeName       string
+		namespace      string
+		policyName     string
+		existingJobs   []client.Object
+		wantErr        bool
+		wantJobCreated bool
+	}{
+		{
+			name:           "creates job successfully",
+			nodeName:       testNodeName,
+			namespace:      testNamespace,
+			policyName:     "test-policy",
+			existingJobs:   nil,
+			wantErr:        false,
+			wantJobCreated: true,
+		},
+		{
+			name:       "skips when job already running",
+			nodeName:   testNodeName,
+			namespace:  testNamespace,
+			policyName: "test-policy",
+			existingJobs: []client.Object{
+				createTestJob(testNamespace, "existing-job", testNodeName, "test-policy", testAction, 0, 0),
+			},
+			wantErr:        false,
+			wantJobCreated: false, // Should skip
+		},
+		{
+			name:       "creates job when previous job completed long ago",
+			nodeName:   testNodeName,
+			namespace:  testNamespace,
+			policyName: "test-policy",
+			existingJobs: []client.Object{
+				createTestJob(testNamespace, "completed-job", testNodeName, "test-policy", testAction, 1, 0),
+			},
+			wantErr:        false,
+			wantJobCreated: true,
+		},
+		{
+			name:       "skips when job was recently created",
+			nodeName:   testNodeName,
+			namespace:  testNamespace,
+			policyName: "test-policy",
+			existingJobs: []client.Object{
+				createTestJobWithCreationTime(testNamespace, "recent-job", testNodeName, "test-policy", testAction, 1, 0, time.Now().Add(-30*time.Second)),
+			},
+			wantErr:        false,
+			wantJobCreated: false, // Should skip because job was created recently
+		},
+		{
+			name:           "fails when NODE_NAME not set",
+			nodeName:       "",
+			namespace:      testNamespace,
+			policyName:     "test-policy",
+			existingJobs:   nil,
+			wantErr:        true,
+			wantJobCreated: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore original env
+			origNodeName := os.Getenv(config.NodeNameEnvKey)
+			origNamespace := os.Getenv(config.OperatorNamespaceEnvKey)
+			origPodName := os.Getenv("POD_NAME")
+			defer func() {
+				if origNodeName != "" {
+					os.Setenv(config.NodeNameEnvKey, origNodeName)
+				} else {
+					os.Unsetenv(config.NodeNameEnvKey)
+				}
+				if origNamespace != "" {
+					os.Setenv(config.OperatorNamespaceEnvKey, origNamespace)
+				} else {
+					os.Unsetenv(config.OperatorNamespaceEnvKey)
+				}
+				if origPodName != "" {
+					os.Setenv("POD_NAME", origPodName)
+				} else {
+					os.Unsetenv("POD_NAME")
+				}
+			}()
+
+			if tt.nodeName != "" {
+				os.Setenv(config.NodeNameEnvKey, tt.nodeName)
+				os.Setenv("POD_NAME", testPodName)
+			} else {
+				os.Unsetenv(config.NodeNameEnvKey)
+				os.Unsetenv("POD_NAME")
+			}
+			os.Setenv(config.OperatorNamespaceEnvKey, tt.namespace)
+
+			// Create fake client with test pod
+			var objs []runtime.Object
+			objs = append(objs, testPod)
+			for _, obj := range tt.existingJobs {
+				objs = append(objs, obj.(runtime.Object))
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(schemeInstance).
+				WithRuntimeObjects(objs...).
+				Build()
+
+			r := &ReconcileSelinux{
+				client: fakeClient,
+			}
+
+			logger := logf.Log.WithName("test")
+			err := r.createPolicyReloadJob(context.Background(), tt.policyName, testAction, logger)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Check if job was created
+			jobs := &batchv1.JobList{}
+			err = fakeClient.List(context.Background(), jobs)
+			require.NoError(t, err)
+
+			if tt.wantJobCreated {
+				// Should have at least one new job (plus any existing ones)
+				foundNewJob := false
+				for _, job := range jobs.Items {
+					if strings.HasPrefix(job.Name, reloadJobNamePrefix) &&
+						job.Labels["node"] == tt.nodeName &&
+						job.Labels["policy"] == tt.policyName {
+						foundNewJob = true
+
+						// Verify job spec
+						require.Equal(t, tt.nodeName, job.Spec.Template.Spec.NodeName)
+						require.Equal(t, "spod", job.Spec.Template.Spec.ServiceAccountName)
+						require.Len(t, job.Spec.Template.Spec.Containers, 1)
+						require.Equal(t, "semodule-reload", job.Spec.Template.Spec.Containers[0].Name)
+						require.Equal(t, testImage, job.Spec.Template.Spec.Containers[0].Image)
+						require.True(t, *job.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
+						require.Equal(t, "spc_t", job.Spec.Template.Spec.Containers[0].SecurityContext.SELinuxOptions.Type)
+						break
+					}
+				}
+				require.True(t, foundNewJob, "Expected new reload job to be created")
+			}
+		})
+	}
+}
+
+func createTestJob(namespace, name, nodeName, policyName, action string, succeeded, failed int32) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":    "selinux-policy-reload",
+				"node":   nodeName,
+				"policy": policyName,
+				"action": action,
+			},
+		},
+		Status: batchv1.JobStatus{
+			Succeeded: succeeded,
+			Failed:    failed,
+		},
+	}
+}
+
+func createTestJobWithCreationTime(namespace, name, nodeName, policyName, action string, succeeded, failed int32, creationTime time.Time) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.NewTime(creationTime),
+			Labels: map[string]string{
+				"app":    "selinux-policy-reload",
+				"node":   nodeName,
+				"policy": policyName,
+				"action": action,
+			},
+		},
+		Status: batchv1.JobStatus{
+			Succeeded: succeeded,
+			Failed:    failed,
+		},
+	}
+}

--- a/internal/pkg/daemon/selinuxprofile/reload_job_test.go
+++ b/internal/pkg/daemon/selinuxprofile/reload_job_test.go
@@ -178,18 +178,19 @@ func TestCreatePolicyReloadJob(t *testing.T) {
 				WithRuntimeObjects(objs...).
 				Build()
 
-			r := &ReconcileSelinux{
-				client: fakeClient,
-			}
+		r := &ReconcileSelinux{
+			client: fakeClient,
+		}
 
-			logger := logf.Log.WithName("test")
-			err := r.createPolicyReloadJob(context.Background(), tt.policyName, testAction, logger)
+		logger := logf.Log.WithName("test")
+		jobCreated, err := r.createPolicyReloadJob(context.Background(), tt.policyName, testAction, logger)
 
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
+		if tt.wantErr {
+			require.Error(t, err)
+			return
+		}
+		require.NoError(t, err)
+		require.Equal(t, tt.wantJobCreated, jobCreated)
 
 			// Check if job was created
 			jobs := &batchv1.JobList{}

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -400,6 +400,14 @@ semodule -R
 								Name:  "HOME",
 								Value: HomeDirectory,
 							},
+							{
+								Name: "POD_NAME",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.name",
+									},
+								},
+							},
 						},
 						Ports: []corev1.ContainerPort{
 							{

--- a/internal/pkg/manager/spod/setup.go
+++ b/internal/pkg/manager/spod/setup.go
@@ -194,34 +194,12 @@ func (r *ReconcileSPOd) getJsonEnricherVolume(ctx context.Context) (*corev1.Volu
 }
 
 func (r *ReconcileSPOd) getSelinuxdImage(ctx context.Context, node *corev1.Node) (string, error) {
-	operatorCm, err := util.GetOperatorConfigMap(ctx, r.clientReader)
+	selinuxdImage, err := util.GetSelinuxdImage(ctx, r.clientReader, node)
 	if err != nil {
 		return "", err
 	}
-
-	selinuxdImageMapping := operatorCm.Data[util.SelinuxdImageMappingKey]
-
-	selinuxdImageEnvVar, err := util.MatchSelinuxdImageJSONMapping(node, []byte(selinuxdImageMapping))
-	if err != nil {
-		return "", fmt.Errorf("matching selinuxd image: %w", err)
-	}
-
-	// not checking selinuxdImageEnvVar is fine here as os.Getenv returns an empty string in that case
-	selinuxdImage := os.Getenv(selinuxdImageEnvVar)
-	if selinuxdImage != "" {
-		r.log.Info("matched selinuxd image against nodeInfo", "image", selinuxdImage)
-
-		return selinuxdImage, nil
-	}
-
-	selinuxdImage = os.Getenv(selinuxdImageKey)
-	if selinuxdImage != "" {
-		r.log.Info("using selinuxd image from envVar", "image", selinuxdImage)
-
-		return selinuxdImage, nil
-	}
-
-	return "", errors.New("invalid selinuxd image")
+	r.log.Info("using selinuxd image", "image", selinuxdImage)
+	return selinuxdImage, nil
 }
 
 func getEffectiveSPOd(dt *daemonTunables) *appsv1.DaemonSet {

--- a/internal/pkg/nodestatus/nodestatus.go
+++ b/internal/pkg/nodestatus/nodestatus.go
@@ -240,6 +240,42 @@ func (nsf *StatusClient) SetNodeStatus(
 	return nil
 }
 
+func (nsf *StatusClient) GetAnnotation(ctx context.Context, key string) (string, error) {
+	status := secprofnodestatusv1alpha1.SecurityProfileNodeStatus{}
+	if err := nsf.client.Get(ctx, nsf.perNodeStatusNamespacedName(), &status); err != nil {
+		return "", fmt.Errorf("getting node status for annotation: %w", err)
+	}
+
+	if status.Annotations == nil {
+		return "", nil
+	}
+
+	return status.Annotations[key], nil
+}
+
+func (nsf *StatusClient) SetAnnotation(ctx context.Context, key, value string) error {
+	status := secprofnodestatusv1alpha1.SecurityProfileNodeStatus{}
+	if err := nsf.client.Get(ctx, nsf.perNodeStatusNamespacedName(), &status); err != nil {
+		return fmt.Errorf("getting node status for annotation update: %w", err)
+	}
+
+	if status.Annotations == nil {
+		status.Annotations = make(map[string]string)
+	}
+
+	if status.Annotations[key] == value {
+		return nil
+	}
+
+	status.Annotations[key] = value
+
+	if err := nsf.client.Update(ctx, &status); err != nil {
+		return fmt.Errorf("updating node status annotation: %w", err)
+	}
+
+	return nil
+}
+
 func (nsf *StatusClient) Matches(
 	ctx context.Context, polState secprofnodestatusv1alpha1.ProfileState,
 ) (bool, error) {

--- a/internal/pkg/util/kubernetes.go
+++ b/internal/pkg/util/kubernetes.go
@@ -19,6 +19,7 @@ package util
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -154,4 +155,35 @@ func GetOperatorConfigMap(ctx context.Context, c client.Reader) (*corev1.ConfigM
 	}
 
 	return &operatorCm, nil
+}
+
+const selinuxdImageKey = "RELATED_IMAGE_SELINUXD"
+
+// GetSelinuxdImage returns the appropriate selinuxd image for the given node
+// by matching the node's OS against the image mapping in the operator ConfigMap.
+func GetSelinuxdImage(ctx context.Context, c client.Reader, node *corev1.Node) (string, error) {
+	operatorCm, err := GetOperatorConfigMap(ctx, c)
+	if err != nil {
+		return "", err
+	}
+
+	selinuxdImageMapping := operatorCm.Data[SelinuxdImageMappingKey]
+
+	selinuxdImageEnvVar, err := MatchSelinuxdImageJSONMapping(node, []byte(selinuxdImageMapping))
+	if err != nil {
+		return "", fmt.Errorf("matching selinuxd image: %w", err)
+	}
+
+	// not checking selinuxdImageEnvVar is fine here as os.Getenv returns an empty string in that case
+	selinuxdImage := os.Getenv(selinuxdImageEnvVar)
+	if selinuxdImage != "" {
+		return selinuxdImage, nil
+	}
+
+	selinuxdImage = os.Getenv(selinuxdImageKey)
+	if selinuxdImage != "" {
+		return selinuxdImage, nil
+	}
+
+	return "", errors.New("invalid selinuxd image")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
#### What this PR does / why we need it:


## How SELinux Policy Reload Works

### Problem
On RHEL 9/OpenShift 4.20+, `semodule -i` no longer automatically reloads the kernel's in-memory SELinux policy. New profiles are installed to disk but not activated until the next reboot.

### Solution
After installing or removing an SELinux profile, SPO creates a short-lived privileged Kubernetes Job that runs `semodule -R` on the target node to reload the policy.

### Flow
1. `selinuxd` installs profile via `semodule -i` (writes to `/var/lib/selinux`)
2. SPO controller detects profile status change → `Installed`
3. Controller creates a privileged Job on the same node:
   - Mounts `/sys/fs/selinux`, `/etc/selinux`, `/var/lib/selinux`
   - Runs `semodule -R` to reload kernel policy
   - Uses correct selinuxd image based on node OS (via image mapping)
4. Job completes and auto-deletes after 5 minutes (TTL)

### Key Components
| File | Purpose |
|------|---------|
| `reload_job.go` | Creates the privileged Job spec |
| `common_controller.go` | Triggers job after profile install/remove |
| `util.GetSelinuxdImage()` | Selects correct image based on node OS |
| `deploy/base/role.yaml` | RBAC for `spod` SA to create Jobs |

### Security
- Job runs as `privileged: true` with `spc_t` SELinux type
- Only created by spod daemon (runs on each node)
- Auto-cleanup via `TTLSecondsAfterFinished: 300`
- Uses `spod` service account with minimal required permissions

#### Which issue(s) this PR fixes:
https://issues.redhat.com/browse/CMP-3537

#### Does this PR have test?

Yes, unit tests are included in `internal/pkg/daemon/selinuxprofile/reload_job_test.go`:

### `TestGetSelinuxdImageForReload`
Tests image selection logic:
- Uses `RELATED_IMAGE_SELINUXD` env var when set
- Falls back to default image when env not set

### `TestCreatePolicyReloadJob`
Tests Job creation with 4 scenarios:
| Test Case | Description |
|-----------|-------------|
| creates job successfully | Creates reload job with correct spec |
| skips when job already running | Avoids duplicate jobs on same node |
| creates job when previous job completed | Allows new job after completion |
| fails when NODE_NAME not set | Returns error gracefully |

Tests verify:
- Correct node affinity (`NodeName`)
- Service account (`spod`)
- Container security context (`privileged: true`, SELinux type `spc_t`)
- Job labels for tracking (`app`, `node`, `policy`)
- 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
```release-note

```
