### PR TITLE
Bump operator image to latest successful build

### DIFF
--- a/bundle-hack/update_csv.go
+++ b/bundle-hack/update_csv.go
@@ -198,7 +198,7 @@ func replaceImages(m map[string]interface{}) error {
 		{
 			EnvName: "RELATED_IMAGE_OPERATOR",
 			// To trigger a rebuild of the bundle
-			KonfluxPS:  "quay.io/redhat-user-workloads/ocp-isc-tenant/security-profiles-operator-release@sha256:e1a8205c814e36320d7b63ceb7c88d284fbc01a38c93691639e4229517cb8fb1",
+			KonfluxPS:  "quay.io/redhat-user-workloads/ocp-isc-tenant/security-profiles-operator-release@sha256:d21d88c128307ff2a91828c86b9382d10a0021b1240cf94d38ad7ae6c1ca58cc",
 			RedHatBase: "registry.redhat.io/compliance/openshift-security-profiles-rhel8-operator",
 		},
 		{


### PR DESCRIPTION
Bump operator pull spec to the build from:
https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/ocp-isc-tenant/applications/security-profiles-operator-release-0-10/commit/6d73aa0317be1b212b847f6a472d227cf7cf4c6e

