### PR TITLE
Separate build triggers for operator and bundle

### DIFF
--- a/.tekton/security-profiles-operator-release-0-10-pull-request.yaml
+++ b/.tekton/security-profiles-operator-release-0-10-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-0.10"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-0.10" && !files.all.all(x, x.matches('^bundle/') || x.matches('^bundle-hack/') || x.matches('^bundle\\.openshift\\.Dockerfile') || x.matches('^\\.tekton/security-profiles-operator-bundle-.*\\.yaml'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: security-profiles-operator-release-0-10

--- a/.tekton/security-profiles-operator-release-0-10-push.yaml
+++ b/.tekton/security-profiles-operator-release-0-10-push.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-0.10"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-0.10" && !files.all.all(x, x.matches('^bundle/') || x.matches('^bundle-hack/') || x.matches('^bundle\\.openshift\\.Dockerfile') || x.matches('^\\.tekton/security-profiles-operator-bundle-.*\\.yaml'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: security-profiles-operator-release-0-10


### PR DESCRIPTION
This will prevent us from building and re-building the operator image unnecessary.

Without this, every time a bundle is built, the operator is built as well.
Then, in subsequent builds, any Konflux snapshot created from new bundle build will contain an operator image which is not aligned with `bundle-hack/update_csv.go`.

Based on the following doc:
https://pipelinesascode.com/docs/guide/matchingevents/#filtering-pipelineruns-to-exclude-non-code-changes
