### PR TITLE
Update golang builder

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -18,7 +18,7 @@
 # for more details
 
 # hash below referred to latest
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.20 AS build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS build
 USER root
 WORKDIR /work
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind failing-test

#### What this PR does / why we need it:
 registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.20 doesn't exist:
 
$ podman pull registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.20
Trying to pull registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.20...
Error: unable to copy from source docker://registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.20: initializing source docker://registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.20: reading manifest rhel-9-golang-1.25-openshift-4.20 in registry.ci.openshift.org/ocp/builder: manifest unknown

$ podman pull registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
Trying to pull registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22...
Getting image source signatures
Copying blob ea57f900cb6c skipped: already exists  
Copying blob 5e09f8650bc2 skipped: already exists  
Copying blob a43f62723025 skipped: already exists  
Copying config 6647c1d0f8 done   | 
Writing manifest to image destination
6647c1d0f8cd93cff487efd3637a8447ee78c17cbd46a75f5005cbe2490378b0



#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
