### PR TITLE
CMP-4050: fix json-enricher volume/mount dedup logic to replace instead of skip

### DIFF
--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -645,26 +645,30 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		jsonEnricherLogVolumeSource, jsonEnricherLogVolumeMountPath, err := r.getJsonEnricherVolume(ctx)
 		if err == nil && jsonEnricherLogVolumeSource != nil {
 			logVolume, logMount := bindata.CustomLogVolume(jsonEnricherLogVolumeMountPath, jsonEnricherLogVolumeSource)
-			// Check if the volume already exists to avoid duplicates
-			volumeExists := false
-			for _, v := range templateSpec.Volumes {
+			// Replace existing volume or append if not found.
+			// Using replace (not skip) so that ConfigMap changes to the volume source
+			// or mount path are applied even when baseSPOd already has an older version.
+			volumeReplaced := false
+			for i, v := range templateSpec.Volumes {
 				if v.Name == logVolume.Name {
-					volumeExists = true
+					templateSpec.Volumes[i] = logVolume
+					volumeReplaced = true
 					break
 				}
 			}
-			if !volumeExists {
+			if !volumeReplaced {
 				templateSpec.Volumes = append(templateSpec.Volumes, logVolume)
 			}
-			// Check if the mount already exists to avoid duplicates
-			mountExists := false
-			for _, m := range ctr.VolumeMounts {
+			// Replace existing mount or append if not found.
+			mountReplaced := false
+			for i, m := range ctr.VolumeMounts {
 				if m.Name == logMount.Name {
-					mountExists = true
+					ctr.VolumeMounts[i] = logMount
+					mountReplaced = true
 					break
 				}
 			}
-			if !mountExists {
+			if !mountReplaced {
 				ctr.VolumeMounts = append(ctr.VolumeMounts, logMount)
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The json-enricher log volume dedup logic in `getConfiguredSPOd` was skipping
volumes/mounts when one with the same name already existed in `baseSPOd`.
This prevented updated ConfigMap values (volume source, mount path) from
propagating to the DaemonSet pod template, causing the json-enricher
container to crash on mismatched mount paths.

This fix changes the logic to **replace** existing volumes/mounts by name
instead of skipping them, ensuring the latest ConfigMap values are always
applied during reconciliation.

#### Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CMP-4050

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

The `baseSPOd` is initialized at operator startup with ConfigMap values from
`getTunables()`. If the ConfigMap is later patched (e.g. changing mount path
from `/data/logs/jsonenricher` to `/tmp/logs`), the old dedup logic would see
the volume name already exists and skip it, leaving stale values in the
DaemonSet spec. The replace logic fixes this.

#### Does this PR introduce a user-facing change?

```release-note
Fix json-enricher container crash caused by stale volume configuration not being updated in DaemonSet spec.
```